### PR TITLE
検索ページのUIの基本部分を実装

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		088BA86FF78AE6BEA9D582E9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9555A1D312DA92CA622456DC /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		2EE165EA2C1B25C3882D234F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F65AE226717C6D3E79F4A7CD /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -30,15 +30,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		10206A8E065008FF529FC291 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		1DDC84975DCC4D9C16EDB2CF /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		1977CB92ED342986ECEB36BC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		54030BF36E38AECFA903E7EE /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		9555A1D312DA92CA622456DC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		91D3A799EDD6816FF5A3E8CD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -46,7 +46,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F1BA04463BF4758182DEF011 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F65AE226717C6D3E79F4A7CD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,22 +54,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				088BA86FF78AE6BEA9D582E9 /* Pods_Runner.framework in Frameworks */,
+				2EE165EA2C1B25C3882D234F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		426640A1E8D436545C54F717 /* Pods */ = {
+		2E5C280702F55C9F9A37F544 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				10206A8E065008FF529FC291 /* Pods-Runner.debug.xcconfig */,
-				F1BA04463BF4758182DEF011 /* Pods-Runner.release.xcconfig */,
-				1DDC84975DCC4D9C16EDB2CF /* Pods-Runner.profile.xcconfig */,
+				54030BF36E38AECFA903E7EE /* Pods-Runner.debug.xcconfig */,
+				1977CB92ED342986ECEB36BC /* Pods-Runner.release.xcconfig */,
+				91D3A799EDD6816FF5A3E8CD /* Pods-Runner.profile.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		57A5BEAA6FED96310B38AFDE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F65AE226717C6D3E79F4A7CD /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -89,8 +97,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
-				426640A1E8D436545C54F717 /* Pods */,
-				992A4BF51017BB82C0402C48 /* Frameworks */,
+				2E5C280702F55C9F9A37F544 /* Pods */,
+				57A5BEAA6FED96310B38AFDE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -117,14 +125,6 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		992A4BF51017BB82C0402C48 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				9555A1D312DA92CA622456DC /* Pods_Runner.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -132,7 +132,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				9F1E6E02F95D15631E3F88AE /* [CP] Check Pods Manifest.lock */,
+				D52ABE95457EA90B56ECB4D9 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -225,7 +225,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		9F1E6E02F95D15631E3F88AE /* [CP] Check Pods Manifest.lock */ = {
+		D52ABE95457EA90B56ECB4D9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-
-class MainPage extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(title: const Text('YouTubeSearchApp')),
-        body: const Center(child: Text('Hello World!')),
-      );
-}

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:youtube_search_app/main_page.dart';
+import 'package:youtube_search_app/search/search_page.dart';
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MaterialApp(
         title: 'YouTubeSearchApp',
         theme: ThemeData(primarySwatch: Colors.blue),
-        home: MainPage(),
+        home: SearchPage(),
       );
 }

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -1,7 +1,10 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:youtube_search_app/search/search_page_bloc.dart';
 import 'package:youtube_search_app/search/search_page_drawer.dart';
+import 'package:youtube_search_app/search/search_page_list.dart';
 
 //  検索ページ
 class SearchPage extends StatelessWidget {
@@ -53,7 +56,9 @@ class _SearchPageContent extends StatelessWidget {
 
   //  ボディを生成する。
   Widget _buildBody(BuildContext context) => GestureDetector(
-        child: this._buildGuideMessage(),
+        //  本来はリストの有無によって分岐するが、現段階では仮にこうしておく。
+        child:
+            Random().nextBool() ? SearchPageList() : this._buildGuideMessage(),
         onTap: () => this._dismissKeyboard(context),
       );
 

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/search_page_drawer.dart';
+
+//  検索ページ
+class SearchPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Provider<SearchPageBloc>(
+        create: (context) => SearchPageBloc(),
+        dispose: (context, bloc) => bloc.dispose(),
+        child: _SearchPageContent(),
+      );
+}
+
+//  検索ページのコンテンツ
+class _SearchPageContent extends StatelessWidget {
+  final _controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: this._buildAppBar(context),
+        drawer: SearchPageDrawer(),
+        body: this._buildBody(context),
+      );
+
+  //  アプリバーを生成する。
+  PreferredSizeWidget _buildAppBar(BuildContext context) => AppBar(
+        title: this._buildKeywordField(context),
+        actions: [this._buildFilterIcon()],
+      );
+
+  //  キーワードフィールドを生成する。
+  Widget _buildKeywordField(BuildContext context) => TextField(
+        controller: this._controller,
+        keyboardType: TextInputType.text,
+        textInputAction: TextInputAction.search,
+        style: const TextStyle(color: Colors.white),
+        cursorColor: Colors.white,
+        decoration: const InputDecoration(
+          border: InputBorder.none,
+          hintText: '検索キーワード',
+          hintStyle: TextStyle(color: Colors.white),
+        ),
+        onEditingComplete: () => this._onKeywordEditingCompleted(context),
+      );
+
+  //  フィルタアイコンを生成する。
+  Widget _buildFilterIcon() => IconButton(
+        icon: const Icon(Icons.filter_list),
+        onPressed: () => this._onFilterIconPressed(),
+      );
+
+  //  ボディを生成する。
+  Widget _buildBody(BuildContext context) => GestureDetector(
+        child: this._buildGuideMessage(),
+        onTap: () => this._dismissKeyboard(context),
+      );
+
+  //  ガイドメッセージを生成する。
+  //  GestureDetectorのタッチ判定範囲を広げるため、透明の背景を追加している。
+  Widget _buildGuideMessage() => Container(
+        color: Colors.transparent,
+        child: const Center(child: Text('検索キーワードを入力してください。')),
+      );
+
+  //  フィルタアイコンが押されたとき。
+  void _onFilterIconPressed() {}
+
+  //  キーワードの編集が完了したとき。
+  void _onKeywordEditingCompleted(BuildContext context) {
+    this._dismissKeyboard(context);
+  }
+
+  //  キーボードを非表示にする。
+  void _dismissKeyboard(BuildContext context) {
+    final currentScope = FocusScope.of(context);
+    if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+      FocusManager.instance.primaryFocus.unfocus();
+    }
+  }
+}

--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -1,0 +1,5 @@
+//  検索ページのBLoC
+class SearchPageBloc {
+  //  終了処理を行う。
+  void dispose() {}
+}

--- a/lib/search/search_page_drawer.dart
+++ b/lib/search/search_page_drawer.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+//  検索ページのDrawer
+class SearchPageDrawer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Drawer(child: Container());
+}

--- a/lib/search/search_page_list.dart
+++ b/lib/search/search_page_list.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:youtube_search_app/search/trail_progress_view.dart';
+import 'package:youtube_search_app/search/video_view.dart';
+
+//  検索ページのリスト
+class SearchPageList extends StatelessWidget {
+  final _controller = ScrollController();
+
+  @override
+  Widget build(BuildContext context) => this._buildList();
+
+  //  リストを生成する。
+  Widget _buildList() => RefreshIndicator(
+        child: Scrollbar(
+          controller: this._controller,
+          child: ListView.builder(
+            controller: this._controller,
+            itemCount: 30,
+            itemBuilder: this._buildListElement,
+          ),
+        ),
+        onRefresh: () => this._onRefresh(),
+      );
+
+  //  リスト要素を生成する。
+  Widget _buildListElement(BuildContext context, int index) =>
+      index != 29 ? VideoView(index, null) : TrailProgressView();
+
+  //  スワイプ更新が掛けられたとき。
+  Future<void> _onRefresh() async {
+    await Future<void>.delayed(const Duration(seconds: 2));
+  }
+}

--- a/lib/search/trail_progress_view.dart
+++ b/lib/search/trail_progress_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+//  検索ページのリストの末尾要素
+//  リストを末尾までスクロールしたときに自動で追加取得を行うときのView
+class TrailProgressView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: VisibilityDetector(
+          key: const Key('IndicatorKey'),
+          child: const Center(child: CircularProgressIndicator()),
+          onVisibilityChanged: (info) => this._onVisibilityChanged(info),
+        ),
+      );
+
+  //  ProgressIndicatorの可視性が変化したとき。
+  void _onVisibilityChanged(VisibilityInfo info) {}
+}

--- a/lib/search/video_view.dart
+++ b/lib/search/video_view.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+//  検索ページのリストの動画の要素
+class VideoView extends StatelessWidget {
+  const VideoView(this.index, this.model);
+
+  //  サムネイル画像のアスペクト比
+  static const _thumbnailAspectRatio = 320.0 / 180.0;
+
+  final int index;
+  final Object model;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.fromLTRB(8.0, 0.0, 16.0, 8.0),
+        child: Card(
+          elevation: 3.0,
+          child: InkWell(
+            child: this._buildCardContents(),
+            onTap: () => this._onTap(),
+            onLongPress: () => this._onLongPress(),
+          ),
+        ),
+      );
+
+  //  Card内のコンテンツを生成する。
+  Widget _buildCardContents() => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          this._buildVideoThumbnail(),
+          this._buildVideoTitle(),
+          this._buildChannelTitle(),
+          this._buildUploadedAt(),
+        ],
+      );
+
+  //  動画のサムネイルを生成する。
+  Widget _buildVideoThumbnail() => Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Container(
+          child: AspectRatio(
+            aspectRatio: _thumbnailAspectRatio,
+            child: Image.network(
+              'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
+              fit: BoxFit.fill,
+              isAntiAlias: true,
+            ),
+          ),
+        ),
+      );
+
+  //  動画のタイトルを生成する。
+  Widget _buildVideoTitle() => const Padding(
+        padding: EdgeInsets.fromLTRB(16.0, 4.0, 16.0, 4.0),
+        child: Text('動画タイトル', style: TextStyle(color: Colors.black)),
+      );
+
+  //  チャンネル名を生成する。
+  Widget _buildChannelTitle() => const Padding(
+        padding: EdgeInsets.fromLTRB(16.0, 4.0, 16.0, 4.0),
+        child: Text('チャンネル名', style: TextStyle(color: Colors.black87)),
+      );
+
+  //  動画の投稿日時を生成する。
+  Widget _buildUploadedAt() => const Padding(
+        padding: EdgeInsets.fromLTRB(16.0, 4.0, 16.0, 4.0),
+        child: Text('投稿日時', style: TextStyle(color: Colors.black87)),
+      );
+
+  //  この動画要素がタップされたとき。
+  void _onTap() {}
+
+  //  この動画要素が長押しされたとき。
+  void _onLongPress() {}
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -373,6 +373,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.5"
+  visibility_detector:
+    dependency: "direct main"
+    description:
+      name: visibility_detector
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   vm_service:
     dependency: transitive
     description:
@@ -410,4 +417,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=1.16.0 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -179,6 +179,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.7"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   node_interop:
     dependency: transitive
     description:
@@ -228,6 +235,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0-nullsafety.3"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2+3"
   pub_semver:
     dependency: transitive
     description:
@@ -235,6 +249,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.25.0"
   shelf:
     dependency: transitive
     description:
@@ -389,3 +410,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.1
   rxdart: ^0.25.0
   provider: ^4.3.2+3
+  visibility_detector: ^0.1.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.1
+  rxdart: ^0.25.0
+  provider: ^4.3.2+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#4 の対応

* `SearchPage` を作成し、そこを "検索ページ" とした。
  * `Scaffold` ベースのデザインでアプリバーとDrawerを追加
* RxDartとproviderを導入
* `SearchPageBloc` という名前でBLoCを定義 (現在ほとんど空)
* 検索結果の動画リストを `SearchPageList` という名前で実装
  * 要素のWidgetを `VideoView` と `TrailProgressView` という名前で実装
  * 前者は検索結果の動画の要素
  * 後者はリスト末尾の自動追加取得用の `ProgressIndicator`
    * `visibility_detector` を導入
    * `ProgressIndicator` 表示時に自動更新ができるようにするため。

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-01-01 at 10 21 45](https://user-images.githubusercontent.com/11826756/103431953-b20daa00-4c1b-11eb-9d51-abe3a68d231e.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-01-01 at 10 21 32](https://user-images.githubusercontent.com/11826756/103431956-b5a13100-4c1b-11eb-8e57-597dd01d5916.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-01-01 at 10 21 23](https://user-images.githubusercontent.com/11826756/103431957-b6d25e00-4c1b-11eb-9d28-121d2cd97bc7.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-01-01 at 10 21 19](https://user-images.githubusercontent.com/11826756/103431959-b76af480-4c1b-11eb-8be1-451666ac8368.png)
