### PR TITLE
Video型を定義

### DIFF
--- a/lib/dummy_video.dart
+++ b/lib/dummy_video.dart
@@ -1,0 +1,15 @@
+import 'package:youtube_search_app/video.dart';
+
+//  ダミーの動画のモデル
+class DummyVideo extends Video {
+  DummyVideo()
+      : super(
+          'VIDEO_ID',
+          '動画タイトル',
+          '動画説明',
+          'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
+          DateTime(2021, 1, 1, 12, 0),
+          'CHANNEL_ID',
+          'チャンネル名',
+        );
+}

--- a/lib/video.dart
+++ b/lib/video.dart
@@ -1,0 +1,47 @@
+//  動画のモデル
+class Video {
+  Video(
+    this.videoId,
+    this.title,
+    this.description,
+    this.thumbnailUrl,
+    this.uploadedAt,
+    this.channelId,
+    this.channelTitle,
+  );
+
+  //  動画ID
+  final String videoId;
+
+  //  動画タイトル
+  final String title;
+
+  //  動画説明
+  final String description;
+
+  //  動画サムネイルのURL
+  final String thumbnailUrl;
+
+  //  動画の投稿日時
+  final DateTime uploadedAt;
+
+  //  この動画を投稿したチャンネルID
+  final String channelId;
+
+  //  この動画を投稿したチャンネル名
+  final String channelTitle;
+
+  //  動画のURL
+  String get videoUrl => 'https://www.youtube.com/watch?v=${this.videoId}';
+
+  @override
+  String toString() => 'Video('
+      'videoId=$videoId, '
+      'title=$title, '
+      'description=$description, '
+      'thumbnailUrl=$thumbnailUrl, '
+      'uploadedAt=$uploadedAt, '
+      'channelId=$channelId, '
+      'channelTitle=$channelTitle'
+      ')';
+}


### PR DESCRIPTION
#5 の対応

* `Video` という名前で動画を表すモデルを定義
  * YouTubeの検索APIで取得できる動画データの `snippet` の内容をもたせただけのシンプルなモデル
* `DummyVideo` という名前でダミーの動画データも定義

