### PR TITLE
検索画面のBLoCの正常系を実装

### DIFF
--- a/lib/search/list_element.dart
+++ b/lib/search/list_element.dart
@@ -1,0 +1,14 @@
+import 'package:youtube_search_app/video.dart';
+
+//  検索ページのリスト要素
+abstract class ListElement {}
+
+//  動画要素
+class VideoElement extends ListElement {
+  VideoElement(this.model);
+
+  final Video model;
+}
+
+//  末尾のProgressIndicator要素
+class ProgressIndicatorElement extends ListElement {}

--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -1,5 +1,129 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:youtube_search_app/dummy_video.dart';
+import 'package:youtube_search_app/search/list_element.dart';
+import 'package:youtube_search_app/video.dart';
+
 //  検索ページのBLoC
 class SearchPageBloc {
+  //  動画リスト
+  final _videoList = BehaviorSubject<List<Video>>.seeded(List.empty());
+
+  //  動画リスト末尾に要素を追加可能かどうか
+  final _isAppendable = BehaviorSubject.seeded(false);
+
+  //  取得中かどうか
+  //  (検索キーワードの入力でEnterが押された直後の状態)
+  final _isFetching = BehaviorSubject.seeded(false);
+
+  //  スワイプ更新中かどうか
+  //  (スワイプによる更新が行われている状態)
+  final _isSwipeRefreshing = BehaviorSubject.seeded(false);
+
+  //  追加取得中かどうか
+  //  (リスト末尾まで到達した際の追加取得が行われている状態)
+  final _isFetchingAdditionally = BehaviorSubject.seeded(false);
+
+  //  ビジー状態 (通信状態) かどうか
+  //  (3通りの更新処理のうち、いずれかが行われているかどうか)
+  Stream<bool> get _isBusy => Rx.combineLatest3<bool, bool, bool, bool>(
+        this._isFetching,
+        this._isSwipeRefreshing,
+        this._isFetchingAdditionally,
+        (fetch, swipe, add) => fetch || swipe || add,
+      );
+
+  //  検索ページリスト
+  Stream<List<ListElement>> get list => Rx.combineLatest2(
+      this._videoList, this._isAppendable, this._toSearchPageList);
+
+  //  リストが空ではないかどうか
+  Stream<bool> get isNotEmpty => this.list.map((list) => list.isNotEmpty);
+
+  //  取得中のProgressIndicatorを配置してもよいかどうか
+  Stream<bool> get isProgressIndicatorVisible => this._isFetching.stream;
+
   //  終了処理を行う。
-  void dispose() {}
+  void dispose() {
+    this._videoList.close();
+    this._isAppendable.close();
+    this._isFetching.close();
+    this._isSwipeRefreshing.close();
+    this._isFetchingAdditionally.close();
+  }
+
+  //  検索を行う。
+  Future<void> search() async {
+    //  すでに他の通信処理が始まっている場合は新規に処理は走らせない。
+    if (await this._isBusy.first) return;
+
+    print('検索開始');
+    this._isFetching.add(true);
+
+    await this._dummyDelayForDebug();
+    this._updateListForDebug(5, isAppendable: true);
+
+    this._isFetching.add(false);
+    print('検索終了');
+  }
+
+  //  スワイプ更新を行う。
+  Future<void> refresh() async {
+    //  すでに他の通信処理が始まっている場合は新規に処理は走らせない。
+    if (await this._isBusy.first) return;
+
+    print('スワイプ更新開始');
+    this._isSwipeRefreshing.add(true);
+
+    await this._dummyDelayForDebug();
+    this._updateListForDebug(5, isAppendable: true);
+
+    this._isSwipeRefreshing.add(false);
+    print('スワイプ更新終了');
+  }
+
+  //  追加取得を行う。
+  Future<void> fetchAdditionally() async {
+    //  すでに他の通信処理が始まっている場合は新規に処理は走らせない。
+    if (await this._isBusy.first) return;
+
+    print('追加取得開始');
+    this._isFetchingAdditionally.add(true);
+
+    await this._dummyDelayForDebug();
+    final destSize = this._videoList.value.length + 5;
+    this._updateListForDebug(destSize, isAppendable: destSize < 20);
+
+    this._isFetchingAdditionally.add(false);
+    print('追加取得終了');
+  }
+
+  //  動画リストを検索ページで表示させるためのリストに変換する。
+  List<ListElement> _toSearchPageList(List<Video> videos, bool isAppendable) {
+    //  追加取得が可能な場合のみ、ProgressIndicator要素を末尾に付加する。
+    if (isAppendable) {
+      final totalSize = videos.length + 1;
+      final lastIndex = videos.length;
+
+      return List.generate(
+        totalSize,
+        (i) => (i != lastIndex)
+            ? VideoElement(videos[i])
+            : ProgressIndicatorElement(),
+      );
+    } else {
+      return List.generate(videos.length, (i) => VideoElement(videos[i]));
+    }
+  }
+
+  //  ダミーの遅延を掛ける。
+  //  (デバッグ用)
+  Future<void> _dummyDelayForDebug() =>
+      Future.delayed(const Duration(seconds: 3));
+
+  //  要素数を指定してリストを更新する。
+  //  (デバッグ用)
+  void _updateListForDebug(int size, {bool isAppendable = true}) {
+    this._isAppendable.add(isAppendable);
+    this._videoList.add(List.generate(size, (index) => DummyVideo()));
+  }
 }

--- a/lib/search/search_page_list.dart
+++ b/lib/search/search_page_list.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:youtube_search_app/dummy_video.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/list_element.dart';
 import 'package:youtube_search_app/search/trail_progress_view.dart';
 import 'package:youtube_search_app/search/video_view.dart';
 
@@ -8,27 +10,42 @@ class SearchPageList extends StatelessWidget {
   final _controller = ScrollController();
 
   @override
-  Widget build(BuildContext context) => this._buildList();
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<SearchPageBloc>(context);
 
-  //  リストを生成する。
-  Widget _buildList() => RefreshIndicator(
+    return this._buildRefreshIndicator(bloc);
+  }
+
+  //  RefreshIndicatorを生成する。
+  Widget _buildRefreshIndicator(SearchPageBloc bloc) => RefreshIndicator(
         child: Scrollbar(
           controller: this._controller,
-          child: ListView.builder(
-            controller: this._controller,
-            itemCount: 30,
-            itemBuilder: this._buildListElement,
-          ),
+          child: this._buildList(bloc),
         ),
-        onRefresh: () => this._onRefresh(),
+        onRefresh: () => this._onRefresh(bloc),
+      );
+
+  //  リストを生成する。
+  Widget _buildList(SearchPageBloc bloc) => StreamBuilder<List<ListElement>>(
+        initialData: List.empty(),
+        stream: bloc.list,
+        builder: (context, snapshot) => ListView.builder(
+          controller: this._controller,
+          itemCount: snapshot.data.length,
+          itemBuilder: (_, i) => this._buildListElement(i, snapshot.data[i]),
+        ),
       );
 
   //  リスト要素を生成する。
-  Widget _buildListElement(BuildContext context, int index) =>
-      index != 29 ? VideoView(index, DummyVideo()) : TrailProgressView();
+  Widget _buildListElement(int index, ListElement element) {
+    if (element is VideoElement) return VideoView(index, element.model);
+    if (element is ProgressIndicatorElement) return TrailProgressView();
+
+    throw Exception();
+  }
 
   //  スワイプ更新が掛けられたとき。
-  Future<void> _onRefresh() async {
-    await Future<void>.delayed(const Duration(seconds: 2));
+  Future<void> _onRefresh(SearchPageBloc bloc) async {
+    await bloc.refresh();
   }
 }

--- a/lib/search/trail_progress_view.dart
+++ b/lib/search/trail_progress_view.dart
@@ -1,19 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
 
 //  検索ページのリストの末尾要素
 //  リストを末尾までスクロールしたときに自動で追加取得を行うときのView
 class TrailProgressView extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: VisibilityDetector(
-          key: const Key('IndicatorKey'),
-          child: const Center(child: CircularProgressIndicator()),
-          onVisibilityChanged: (info) => this._onVisibilityChanged(info),
-        ),
-      );
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<SearchPageBloc>(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: VisibilityDetector(
+        key: const Key('IndicatorKey'),
+        child: const Center(child: CircularProgressIndicator()),
+        onVisibilityChanged: (info) => this._onVisibilityChanged(info, bloc),
+      ),
+    );
+  }
 
   //  ProgressIndicatorの可視性が変化したとき。
-  void _onVisibilityChanged(VisibilityInfo info) {}
+  Future<void> _onVisibilityChanged(
+      VisibilityInfo info, SearchPageBloc bloc) async {
+    if (info.visibleFraction > 0.0) await bloc.fetchAdditionally();
+  }
 }


### PR DESCRIPTION
#7 の対応

* `SearchPageBloc` を実装
  * 正常系のみ (現段階ではエラー時のSnackBarなどは一切考慮していない。)
  * ダミーの実装
    * 3秒ほどのダミーの遅延
    * リストの要素を5つずつ追加していく仮実装

現在、データ取得時の処理などを外から注入できないため、BLoCがUse Case Interactorを叩くような実装になってから単体テストを追加する予定である。