### PR TITLE
検索画面のユースケースを定義

### DIFF
--- a/lib/search/usecase/append/stub_video_list_append_interactor.dart
+++ b/lib/search/usecase/append/stub_video_list_append_interactor.dart
@@ -1,0 +1,40 @@
+import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
+import 'package:youtube_search_app/search/usecase/stub_repository.dart';
+import 'package:youtube_search_app/video.dart';
+
+class StubVideoListAppendInteractor implements VideoListAppendUseCase {
+  StubVideoListAppendInteractor(this._repository);
+
+  final StubRepository _repository;
+
+  @override
+  Future<VideoListAppendResponse> execute(
+      VideoListAppendRequest request) async {
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    final currentSize = this._repository.currentVideoList.length;
+    final destSize = currentSize + 5;
+    final hasNextPage = destSize < 25;
+
+    final newList = List.generate(
+      destSize,
+      (i) {
+        final n = i + 1;
+
+        return Video(
+          'VIDEO_ID_$n',
+          'ダミー動画「${this._repository.currentKeyword}」その$n',
+          '動画説明',
+          'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
+          DateTime(2021, 1, 1, 12, 0).add(Duration(minutes: n)),
+          'CHANNEL_ID_$n',
+          'チャンネル その$n',
+        );
+      },
+    );
+
+    this._repository.currentVideoList = newList;
+
+    return VideoListAppendResponseSuccess(newList, hasNextPage);
+  }
+}

--- a/lib/search/usecase/append/video_list_append_use_case.dart
+++ b/lib/search/usecase/append/video_list_append_use_case.dart
@@ -1,0 +1,32 @@
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+import 'package:youtube_search_app/video.dart';
+
+//  動画リストの追加取得を行う。
+abstract class VideoListAppendUseCase {
+  Future<VideoListAppendResponse> execute(VideoListAppendRequest request);
+}
+
+//  リクエスト
+class VideoListAppendRequest {}
+
+//  レスポンス
+abstract class VideoListAppendResponse {}
+
+//  成功
+class VideoListAppendResponseSuccess extends VideoListAppendResponse {
+  VideoListAppendResponseSuccess(this.videoList, this.hasNextPage);
+
+  //  結果の動画リスト
+  final List<Video> videoList;
+
+  //  次のページが存在するかどうか
+  final bool hasNextPage;
+}
+
+//  失敗
+class VideoListAppendResponseFailure extends VideoListAppendResponse {
+  VideoListAppendResponseFailure(this.cause);
+
+  //  エラーの原因
+  final FetchErrorType cause;
+}

--- a/lib/search/usecase/fetch/stub_video_list_fetch_interactor.dart
+++ b/lib/search/usecase/fetch/stub_video_list_fetch_interactor.dart
@@ -1,0 +1,38 @@
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/stub_repository.dart';
+import 'package:youtube_search_app/video.dart';
+
+class StubVideoListFetchInteractor implements VideoListFetchUseCase {
+  StubVideoListFetchInteractor(this._repository);
+
+  final StubRepository _repository;
+
+  @override
+  Future<VideoListFetchResponse> execute(VideoListFetchRequest request) async {
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    const destSize = 10;
+    final newList = List.generate(
+      destSize,
+      (i) {
+        final n = i + 1;
+
+        return Video(
+          'VIDEO_ID_$n',
+          'ダミー動画「${request.keyword}」その$n',
+          '動画説明',
+          'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
+          DateTime(2021, 1, 1, 12, 0).add(Duration(minutes: n)),
+          'CHANNEL_ID_$n',
+          'チャンネル その$n',
+        );
+      },
+    );
+    const hasNextPage = true;
+
+    this._repository.currentKeyword = request.keyword;
+    this._repository.currentVideoList = newList;
+
+    return VideoListFetchResponseSuccess(newList, hasNextPage);
+  }
+}

--- a/lib/search/usecase/fetch/video_list_fetch_use_case.dart
+++ b/lib/search/usecase/fetch/video_list_fetch_use_case.dart
@@ -1,0 +1,41 @@
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+import 'package:youtube_search_app/video.dart';
+
+//  動画リストを取得する。
+abstract class VideoListFetchUseCase {
+  Future<VideoListFetchResponse> execute(VideoListFetchRequest request);
+}
+
+//  リクエスト
+class VideoListFetchRequest {
+  VideoListFetchRequest(this.keyword, this.options);
+
+  //  キーワード
+  final String keyword;
+
+  //  検索オプション
+  //  (仮)
+  final Object options;
+}
+
+//  レスポンス
+abstract class VideoListFetchResponse {}
+
+//  成功
+class VideoListFetchResponseSuccess extends VideoListFetchResponse {
+  VideoListFetchResponseSuccess(this.videoList, this.hasNextPage);
+
+  //  結果の動画リスト
+  final List<Video> videoList;
+
+  //  次のページが存在するかどうか
+  final bool hasNextPage;
+}
+
+//  失敗
+class VideoListFetchResponseFailure extends VideoListFetchResponse {
+  VideoListFetchResponseFailure(this.cause);
+
+  //  エラーの原因
+  final FetchErrorType cause;
+}

--- a/lib/search/usecase/fetch_error_type.dart
+++ b/lib/search/usecase/fetch_error_type.dart
@@ -1,0 +1,13 @@
+//  動画リストの取得エラーの種類
+enum FetchErrorType {
+  //  トークンエラー
+  //  (YouTubeのAPIのリクエスト制限など)
+  TokenError,
+
+  //  クライアントエラー
+  //  (オフライン状態など)
+  ClientError,
+
+  //  その他不明のエラー
+  UnknownError,
+}

--- a/lib/search/usecase/stub_repository.dart
+++ b/lib/search/usecase/stub_repository.dart
@@ -1,0 +1,6 @@
+import 'package:youtube_search_app/video.dart';
+
+class StubRepository {
+  String currentKeyword = null;
+  List<Video> currentVideoList = null;
+}


### PR DESCRIPTION
#12 の対応

検索画面の2つのユースケースを定義した。

* `VideoListFetchUseCase`
  * 新規に取得する際に用いる。
  * 検索キーワードと検索オプション (仮) を入力とする。
  * 成功時に動画リストを、失敗時にエラー原因 (`FetchErrorType`) を出力とする。
* `VideoListAppendUseCase`
  *追加取得する際に用いる。
  * 現時点で入力は空とする。
  * 成功時に動画リストを、失敗時にエラー原因 (`FetchErrorType`) を出力とする。

また、これらのスタブとして

* `StubVideoListFetchInteractor`
* `StubVideoListAppendInteractor`

を追加した。
これらはスタブのリポジトリの `StubRepository` を使った、ダミーデータを返す簡単な実装例である。
