### PR TITLE
get_itを導入

### DIFF
--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -1,0 +1,10 @@
+import 'package:get_it/get_it.dart';
+
+//  DIコンテナのラッパ
+class Dependency {
+  //  依存関係の設定を行う。
+  static void setup() {}
+
+  //  依存関係の解決を行う。
+  static T resolve<T>({String name}) => GetIt.I.get(instanceName: name);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:youtube_search_app/dependency.dart';
 import 'package:youtube_search_app/my_app.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
 
+  Dependency.setup();
   runApp(MyApp());
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,6 +116,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.3"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   provider: ^4.3.2+3
   visibility_detector: ^0.1.5
   intl: ^0.16.1
+  get_it: ^5.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#17 の対応

* `get_it` を導入
* ラッパの `Dependency` 型を導入
  * `Dependency.setup()` で依存関係の登録を行う。
  * `main()` で `Dependency.setup()` を呼び出しておく。
  * `Dependency.resolve<T>()` で依存関係の解決を行う。

ラッパの使い方はこんな感じ 👇

```Dart
//  直接get_itを使わずに `Dependency.resolve()` 経由で依存関係を解決する。
VideoListFetchUseCase videoUseCase = Dependency.resolve();
```
