### PR TITLE
検索キーワードをBLoCと紐付けるように修正

### DIFF
--- a/lib/search/search_keyword_field.dart
+++ b/lib/search/search_keyword_field.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+
+//  検索キーワードの入力フィールド
+class SearchKeywordField extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _SearchKeywordFieldState();
+}
+
+class _SearchKeywordFieldState extends State<SearchKeywordField> {
+  TextEditingController _controller = null;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    this._controller = TextEditingController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<SearchPageBloc>(context);
+
+    return StreamBuilder<String>(
+      initialData: '',
+      stream: bloc.keyword,
+      builder: (context, snapshot) {
+        this._controller.value =
+            this._controller.value.copyWith(text: snapshot.data);
+
+        return this._buildTextField(bloc);
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    this._controller.dispose();
+    super.dispose();
+  }
+
+  Widget _buildTextField(SearchPageBloc bloc) => TextField(
+        controller: this._controller,
+        keyboardType: TextInputType.text,
+        textInputAction: TextInputAction.search,
+        style: const TextStyle(color: Colors.white),
+        cursorColor: Colors.white,
+        decoration: const InputDecoration(
+          border: InputBorder.none,
+          hintText: '検索キーワード',
+          hintStyle: TextStyle(color: Colors.white),
+        ),
+        onChanged: (keyword) => bloc.keywordSink.add(keyword),
+        onEditingComplete: () => this._onKeywordEditingCompleted(context, bloc),
+      );
+
+  Future<void> _onKeywordEditingCompleted(
+      BuildContext context, SearchPageBloc bloc) async {
+    this._dismissKeyboard(context);
+    await bloc.search();
+  }
+
+  //  キーボードを非表示にする。
+  void _dismissKeyboard(BuildContext context) {
+    final currentScope = FocusScope.of(context);
+    if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+      FocusManager.instance.primaryFocus.unfocus();
+    }
+  }
+}

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:youtube_search_app/search/search_page_bloc.dart';
 import 'package:youtube_search_app/search/search_page_drawer.dart';
+import 'package:youtube_search_app/search/search_keyword_field.dart';
 import 'package:youtube_search_app/search/search_page_list.dart';
 
 //  検索ページ
@@ -16,40 +17,21 @@ class SearchPage extends StatelessWidget {
 
 //  検索ページのコンテンツ
 class _SearchPageContent extends StatelessWidget {
-  final _controller = TextEditingController();
-
   @override
   Widget build(BuildContext context) {
     final bloc = Provider.of<SearchPageBloc>(context);
 
     return Scaffold(
-      appBar: this._buildAppBar(context, bloc),
+      appBar: this._buildAppBar(),
       drawer: SearchPageDrawer(),
       body: this._buildBody(context, bloc),
     );
   }
 
   //  アプリバーを生成する。
-  PreferredSizeWidget _buildAppBar(BuildContext context, SearchPageBloc bloc) =>
-      AppBar(
-        title: this._buildKeywordField(context, bloc),
+  PreferredSizeWidget _buildAppBar() => AppBar(
+        title: SearchKeywordField(),
         actions: [this._buildFilterIcon()],
-      );
-
-  //  キーワードフィールドを生成する。
-  Widget _buildKeywordField(BuildContext context, SearchPageBloc bloc) =>
-      TextField(
-        controller: this._controller,
-        keyboardType: TextInputType.text,
-        textInputAction: TextInputAction.search,
-        style: const TextStyle(color: Colors.white),
-        cursorColor: Colors.white,
-        decoration: const InputDecoration(
-          border: InputBorder.none,
-          hintText: '検索キーワード',
-          hintStyle: TextStyle(color: Colors.white),
-        ),
-        onEditingComplete: () => this._onKeywordEditingCompleted(context, bloc),
       );
 
   //  フィルタアイコンを生成する。
@@ -104,13 +86,6 @@ class _SearchPageContent extends StatelessWidget {
 
   //  フィルタアイコンが押されたとき。
   void _onFilterIconPressed() {}
-
-  //  キーワードの編集が完了したとき。
-  Future<void> _onKeywordEditingCompleted(
-      BuildContext context, SearchPageBloc bloc) async {
-    this._dismissKeyboard(context);
-    await bloc.search();
-  }
 
   //  キーボードを非表示にする。
   void _dismissKeyboard(BuildContext context) {

--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -5,6 +5,9 @@ import 'package:youtube_search_app/video.dart';
 
 //  検索ページのBLoC
 class SearchPageBloc {
+  //  検索キーワード
+  final _keyword = BehaviorSubject.seeded('');
+
   //  動画リスト
   final _videoList = BehaviorSubject<List<Video>>.seeded(List.empty());
 
@@ -31,6 +34,12 @@ class SearchPageBloc {
         this._isFetchingAdditionally,
         (fetch, swipe, add) => fetch || swipe || add,
       );
+
+  //  検索キーワードのStream
+  Stream<String> get keyword => this._keyword.stream;
+
+  //  検索キーワードのSink
+  Sink<String> get keywordSink => this._keyword.sink;
 
   //  検索ページリスト
   Stream<List<ListElement>> get list => Rx.combineLatest2(


### PR DESCRIPTION
#14 の対応

* `SearchPageBloc` に `keyword: Stream<String>` と`keywordSink: Sink<String>` を追加
* `SearchKeywordField` という名前で入力フィールドを独立化
  * `StreamBuilder` を使って、BLoCから流れてきた値を反映させるように実装