### PR TITLE
検索ページのBLoCをユースケースを使った実装に変更

### DIFF
--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -1,9 +1,28 @@
 import 'package:get_it/get_it.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/usecase/append/stub_video_list_append_interactor.dart';
+import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch/stub_video_list_fetch_interactor.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/stub_repository.dart';
 
 //  DIコンテナのラッパ
 class Dependency {
   //  依存関係の設定を行う。
-  static void setup() {}
+  static void setup() {
+    GetIt.I.registerLazySingleton(() => StubRepository());
+
+    GetIt.I.registerFactory<VideoListFetchUseCase>(
+      () => StubVideoListFetchInteractor(resolve()),
+    );
+    GetIt.I.registerFactory<VideoListAppendUseCase>(
+      () => StubVideoListAppendInteractor(resolve()),
+    );
+
+    GetIt.I.registerFactory<SearchPageBloc>(
+      () => SearchPageBloc(resolve(), resolve()),
+    );
+  }
 
   //  依存関係の解決を行う。
   static T resolve<T>({String name}) => GetIt.I.get(instanceName: name);

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:youtube_search_app/dependency.dart';
 import 'package:youtube_search_app/search/search_page_bloc.dart';
 import 'package:youtube_search_app/search/search_page_drawer.dart';
 import 'package:youtube_search_app/search/search_keyword_field.dart';
@@ -9,7 +10,7 @@ import 'package:youtube_search_app/search/search_page_list.dart';
 class SearchPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Provider<SearchPageBloc>(
-        create: (context) => SearchPageBloc(),
+        create: (context) => Dependency.resolve(),
         dispose: (context, bloc) => bloc.dispose(),
         child: _SearchPageContent(),
       );


### PR DESCRIPTION
#15 の対応

* DIコンテナへのスタブ実装の登録
* ユースケースを使った実装に変更
  * `VideoListFetchUseCase` と `VideoListAppendUseCase` のコール
  * 結果の `_videoList` と `_isAppendable` への反映

異常系に関しては #13 で対応予定