### PR TITLE
検索画面のBLoCでのBehaviorSubjectのclose()し忘れを修正

### DIFF
--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -53,6 +53,7 @@ class SearchPageBloc {
 
   //  終了処理を行う。
   void dispose() {
+    this._keyword.close();
     this._videoList.close();
     this._isAppendable.close();
     this._isFetching.close();


### PR DESCRIPTION
`SearchPageBloc#_keyword: BehaviorSubject<String>` の `close()` を `dispose()` のタイミングで呼ぶのを忘れていたのを修正