### PR TITLE
検索画面のエラー処理を追加

### DIFF
--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -132,8 +132,11 @@ class SearchPageBloc {
       this._onFetchSuccess(response.videoList, response.hasNextPage);
 
     //  失敗時
-    if (response is VideoListAppendResponseFailure)
+    if (response is VideoListAppendResponseFailure) {
+      //  UIがややこしくなるため、追加取得失敗のリトライはできないようにする。
+      this._isAppendable.add(false);
       this._onFetchFailure(response.cause, clearListOnError: false);
+    }
 
     this._isFetchingAdditionally.add(false);
   }
@@ -164,8 +167,10 @@ class SearchPageBloc {
 
   //  動画リストの取得に失敗したとき。
   void _onFetchFailure(FetchErrorType cause, {bool clearListOnError = true}) {
-    if (clearListOnError) this._videoList.add(List.empty());
-    this._isAppendable.add(false);
+    if (clearListOnError) {
+      this._videoList.add(List.empty());
+      this._isAppendable.add(false);
+    }
     this._errorSubject.add(cause);
   }
 }

--- a/lib/search/search_page_bloc.dart
+++ b/lib/search/search_page_bloc.dart
@@ -33,6 +33,9 @@ class SearchPageBloc {
   //  (リスト末尾まで到達した際の追加取得が行われている状態)
   final _isFetchingAdditionally = BehaviorSubject.seeded(false);
 
+  //  直近のエラーを通知するSubject
+  final _errorSubject = PublishSubject<FetchErrorType>();
+
   //  ビジー状態 (通信状態) かどうか
   //  (3通りの更新処理のうち、いずれかが行われているかどうか)
   Stream<bool> get _isBusy => Rx.combineLatest3<bool, bool, bool, bool>(
@@ -58,6 +61,9 @@ class SearchPageBloc {
   //  取得中のProgressIndicatorを配置してもよいかどうか
   Stream<bool> get isProgressIndicatorVisible => this._isFetching.stream;
 
+  //  エラーを通知するStream
+  Stream<FetchErrorType> get errorStream => this._errorSubject.stream;
+
   //  終了処理を行う。
   void dispose() {
     this._keyword.close();
@@ -66,6 +72,7 @@ class SearchPageBloc {
     this._isFetching.close();
     this._isSwipeRefreshing.close();
     this._isFetchingAdditionally.close();
+    this._errorSubject.close();
   }
 
   //  検索を行う。
@@ -157,9 +164,8 @@ class SearchPageBloc {
 
   //  動画リストの取得に失敗したとき。
   void _onFetchFailure(FetchErrorType cause, {bool clearListOnError = true}) {
-    //  TODO: エラー通知系Streamの発火
-
     if (clearListOnError) this._videoList.add(List.empty());
     this._isAppendable.add(false);
+    this._errorSubject.add(cause);
   }
 }

--- a/lib/search/usecase/append/stub_video_list_append_interactor.dart
+++ b/lib/search/usecase/append/stub_video_list_append_interactor.dart
@@ -1,4 +1,6 @@
+import 'dart:math';
 import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
 import 'package:youtube_search_app/search/usecase/stub_repository.dart';
 import 'package:youtube_search_app/video.dart';
 
@@ -12,29 +14,44 @@ class StubVideoListAppendInteractor implements VideoListAppendUseCase {
       VideoListAppendRequest request) async {
     await Future<void>.delayed(const Duration(seconds: 3));
 
-    final currentSize = this._repository.currentVideoList.length;
-    final destSize = currentSize + 5;
-    final hasNextPage = destSize < 25;
+    switch (Random().nextInt(10)) {
+      case 1:
+        return VideoListAppendResponseFailure(FetchErrorType.TokenError);
 
-    final newList = List.generate(
-      destSize,
-      (i) {
-        final n = i + 1;
+      case 2:
+        return VideoListAppendResponseFailure(FetchErrorType.ClientError);
 
-        return Video(
-          'VIDEO_ID_$n',
-          'ダミー動画「${this._repository.currentKeyword}」その$n',
-          '動画説明',
-          'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
-          DateTime(2021, 1, 1, 12, 0).add(Duration(minutes: n)),
-          'CHANNEL_ID_$n',
-          'チャンネル その$n',
-        );
-      },
-    );
+      case 3:
+        return VideoListAppendResponseFailure(FetchErrorType.UnknownError);
 
-    this._repository.currentVideoList = newList;
+      default:
+        final keyword = this._repository.currentKeyword;
+        final currentSize = this._repository.currentVideoList.length;
+        final destSize = currentSize + 5;
 
-    return VideoListAppendResponseSuccess(newList, hasNextPage);
+        final list = this._createVideoList(destSize, keyword);
+        final hasNextPage = destSize < 25;
+
+        this._repository.currentVideoList = list;
+
+        return VideoListAppendResponseSuccess(list, hasNextPage);
+    }
   }
+
+  List<Video> _createVideoList(int destSize, String keyword) => List.generate(
+        destSize,
+        (i) {
+          final n = i + 1;
+
+          return Video(
+            'VIDEO_ID_$n',
+            'ダミー動画「${this._repository.currentKeyword}」その$n',
+            '動画説明',
+            'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
+            DateTime(2021, 1, 1, 12, 0).add(Duration(minutes: n)),
+            'CHANNEL_ID_$n',
+            'チャンネル その$n',
+          );
+        },
+      );
 }

--- a/lib/search/usecase/fetch/stub_video_list_fetch_interactor.dart
+++ b/lib/search/usecase/fetch/stub_video_list_fetch_interactor.dart
@@ -1,4 +1,6 @@
+import 'dart:math';
 import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
 import 'package:youtube_search_app/search/usecase/stub_repository.dart';
 import 'package:youtube_search_app/video.dart';
 
@@ -11,15 +13,38 @@ class StubVideoListFetchInteractor implements VideoListFetchUseCase {
   Future<VideoListFetchResponse> execute(VideoListFetchRequest request) async {
     await Future<void>.delayed(const Duration(seconds: 3));
 
+    switch (Random().nextInt(10)) {
+      case 1:
+        return VideoListFetchResponseFailure(FetchErrorType.TokenError);
+
+      case 2:
+        return VideoListFetchResponseFailure(FetchErrorType.ClientError);
+
+      case 3:
+        return VideoListFetchResponseFailure(FetchErrorType.UnknownError);
+
+      default:
+        final list = this._createVideoList(request.keyword);
+        const hasNextPage = true;
+
+        this._repository.currentKeyword = request.keyword;
+        this._repository.currentVideoList = list;
+
+        return VideoListFetchResponseSuccess(list, hasNextPage);
+    }
+  }
+
+  List<Video> _createVideoList(String keyword) {
     const destSize = 10;
-    final newList = List.generate(
+
+    return List.generate(
       destSize,
       (i) {
         final n = i + 1;
 
         return Video(
           'VIDEO_ID_$n',
-          'ダミー動画「${request.keyword}」その$n',
+          'ダミー動画「$keyword」その$n',
           '動画説明',
           'https://placehold.jp/26/000000/FFFFFF/320x180.png?text=THUMBNAIL',
           DateTime(2021, 1, 1, 12, 0).add(Duration(minutes: n)),
@@ -28,11 +53,5 @@ class StubVideoListFetchInteractor implements VideoListFetchUseCase {
         );
       },
     );
-    const hasNextPage = true;
-
-    this._repository.currentKeyword = request.keyword;
-    this._repository.currentVideoList = newList;
-
-    return VideoListFetchResponseSuccess(newList, hasNextPage);
   }
 }


### PR DESCRIPTION
#13 の対応

ユースケースインタラクタ実行失敗時にSnackBarを表示するようにした。

| エラー種類 | メッセージ |
|:---|:---|
| TokenError | "時間をおいてからリトライしてください。" |
| ClientError | "インターネット環境を確認してリトライしてください。" |
| UnknownError | "エラーが発生しました。時間をおいてからリトライしてください。" |