### PR TITLE
検索画面のBLoCのテストを実装

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0-nullsafety.3"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.0"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.1.0"
   characters:
     dependency: transitive
     description:
@@ -64,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety.3"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   collection:
     dependency: transitive
     description:
@@ -99,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.10"
   fake_async:
     dependency: transitive
     description:
@@ -106,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0-nullsafety.3"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.11"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -193,6 +235,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.7"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.3"
   nested:
     dependency: transitive
     description:
@@ -263,6 +312,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
   rxdart:
     dependency: "direct main"
     description:
@@ -303,6 +359,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.10+1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.15.7
+  mockito: ^4.1.3
 
 flutter:
   uses-material-design: true

--- a/test/matchers.dart
+++ b/test/matchers.dart
@@ -1,0 +1,11 @@
+import 'package:test/test.dart';
+import 'package:youtube_search_app/search/list_element.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+
+//  VideoListFetchUseCaseのリクエストに渡した検索キーワードのMatcherを生成する。
+Matcher searchKeywordEquals(String keyword) =>
+    predicate<VideoListFetchRequest>((r) => r.keyword == keyword);
+
+//  List<ListElement>に対するMatcherを生成する。
+typedef ListPredicate = bool Function(List<ListElement> list);
+Matcher listPredicate(ListPredicate listPredicate) => predicate(listPredicate);

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,0 +1,10 @@
+import 'package:mockito/mockito.dart';
+import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+
+//  VideoListFetchUseCaseのモック
+class MockVideoListFetchUseCase extends Mock implements VideoListFetchUseCase {}
+
+//  VideoListAppendUseCaseのモック
+class MockVideoListAppendUseCase extends Mock
+    implements VideoListAppendUseCase {}

--- a/test/my_test.dart
+++ b/test/my_test.dart
@@ -1,7 +1,0 @@
-import 'package:test/test.dart';
-
-void main() {
-  test('テスト', () {
-    expect(3, equals(1 + 2));
-  });
-}

--- a/test/search_page_bloc_append_test.dart
+++ b/test/search_page_bloc_append_test.dart
@@ -1,0 +1,123 @@
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+import 'package:youtube_search_app/dummy_video.dart';
+import 'package:youtube_search_app/search/list_element.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+
+import 'matchers.dart';
+import 'mocks.dart';
+
+void main() {
+  group('SearchPageBlocのテスト', () {
+    final mockFetchUseCase = MockVideoListFetchUseCase();
+    final mockAppendUseCase = MockVideoListAppendUseCase();
+
+    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+    const keyword = '検索キーワードてすと';
+
+    group('追加取得のテスト', () {
+      test('追加取得に成功するケース', () async {
+        //  最初の検索をするところまで進める。
+        await runFirstTimeSearch(bloc, mockFetchUseCase, keyword);
+
+        //  呼び出し回数などをリセットする。
+        reset(mockFetchUseCase);
+
+        //  追加取得に成功し、8件の動画が見つかり、追加取得が可能
+        //  という結果を返すように設定する。
+        final videoList = List.generate(8, (_) => DummyVideo());
+        const hasNextPage = true;
+        final response = VideoListAppendResponseSuccess(videoList, hasNextPage);
+        when(mockAppendUseCase.execute(any)).thenAnswer((_) async => response);
+
+        //  追加取得を行う。
+        await bloc.fetchAdditionally();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockAppendUseCase.execute(any)).called(1);
+
+        //  リストが更新されているはず。
+        expect(
+          bloc.list,
+          emits(
+            listPredicate(
+              //  動画8件と末尾のProgressIndicator要素で、合わせて9件のはず。
+              (l) => l.length == 9 && l.last is ProgressIndicatorElement,
+            ),
+          ),
+        );
+
+        //  動画リストが空でないはず。
+        expect(bloc.isNotEmpty, emits(equals(true)));
+      });
+
+      test('追加取得に失敗するケース', () async {
+        //  呼び出し回数などをリセットする。
+        reset(mockFetchUseCase);
+
+        //  errorStreamをReplaySubjectで記録する。
+        final errorStream = ReplaySubject<FetchErrorType>()
+          ..addStream(bloc.errorStream);
+
+        //  追加取得に失敗するように設定する。
+        const error = FetchErrorType.UnknownError;
+        when(mockAppendUseCase.execute(any))
+            .thenAnswer((_) async => VideoListAppendResponseFailure(error));
+
+        //  追加取得を行う。
+        await bloc.fetchAdditionally();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockAppendUseCase.execute(any)).called(1);
+
+        //  エラーが通知されているはず。
+        expect(errorStream, emits(equals(error)));
+
+        //  追加取得時は失敗すると元のリストの内容のまま、次の追加取得が無効化される。
+        expect(
+          bloc.list,
+          emits(
+            listPredicate(
+              //  末尾のProgressIndicator要素がなくなったため、全部で8件になっているはず。
+              (l) => l.length == 8 && l.every((e) => e is VideoElement),
+            ),
+          ),
+        );
+
+        //  動画リストが空でないはず。
+        expect(bloc.isNotEmpty, emits(equals(true)));
+      });
+    });
+  });
+}
+
+//  最初の検索部分まで処理を進める。
+Future<void> runFirstTimeSearch(
+  SearchPageBloc bloc,
+  MockVideoListFetchUseCase mockFetchUseCase,
+  String keyword,
+) async {
+  when(mockFetchUseCase.execute(any)).thenAnswer(
+    (_) async => VideoListFetchResponseSuccess(
+      List.generate(1, (_) => DummyVideo()),
+      true,
+    ),
+  );
+
+  bloc.keywordSink.add(keyword);
+  await bloc.search();
+
+  //  現在、動画リスト1件で追加取得可能な状態となっている。
+  expect(
+    bloc.list,
+    emits(
+      listPredicate(
+        (l) => l.length == 2 && l.last is ProgressIndicatorElement,
+      ),
+    ),
+  );
+}

--- a/test/search_page_bloc_refresh_test.dart
+++ b/test/search_page_bloc_refresh_test.dart
@@ -1,0 +1,126 @@
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+import 'package:youtube_search_app/dummy_video.dart';
+import 'package:youtube_search_app/search/list_element.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+
+import 'matchers.dart';
+import 'mocks.dart';
+
+void main() {
+  group('SearchPageBlocのテスト', () {
+    final mockFetchUseCase = MockVideoListFetchUseCase();
+    final mockAppendUseCase = MockVideoListAppendUseCase();
+
+    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+    const keyword = '検索キーワードてすと';
+
+    group('スワイプ更新のテスト', () {
+      test('スワイプ更新に成功するケース', () async {
+        //  最初の検索をするところまで進める。
+        await runFirstTimeSearch(bloc, mockFetchUseCase, keyword);
+
+        //  呼び出し回数などをリセットする。
+        reset(mockFetchUseCase);
+
+        //  スワイプ更新に成功し、4件の動画が見つかり、追加取得が可能
+        //  という結果を返すように設定する。
+        final videoList = List.generate(4, (_) => DummyVideo());
+        const hasNextPage = true;
+        final response = VideoListFetchResponseSuccess(videoList, hasNextPage);
+        when(mockFetchUseCase.execute(any)).thenAnswer((_) async => response);
+
+        //  スワイプ更新を掛ける。
+        await bloc.refresh();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockFetchUseCase.execute(argThat(searchKeywordEquals(keyword))))
+            .called(1);
+
+        //  リストが更新されているはず。
+        expect(
+          bloc.list,
+          emits(
+            listPredicate(
+              //  動画4件と末尾のProgressIndicator要素で、合わせて5件のはず。
+              (l) => l.length == 5 && l.last is ProgressIndicatorElement,
+            ),
+          ),
+        );
+
+        //  動画リストが空でないことが通知されているはず。
+        expect(bloc.isNotEmpty, emits(equals(true)));
+      });
+
+      test('スワイプ更新に失敗するケース', () async {
+        //  呼び出し回数などをリセットする。
+        reset(mockFetchUseCase);
+
+        //  errorStreamをReplaySubjectで記録する。
+        final errorStream = ReplaySubject<FetchErrorType>()
+          ..addStream(bloc.errorStream);
+
+        //  スワイプ更新に失敗するように設定する。
+        const error = FetchErrorType.ClientError;
+        when(mockFetchUseCase.execute(any)).thenAnswer(
+          (_) async => VideoListFetchResponseFailure(error),
+        );
+
+        //  スワイプ更新を掛ける。
+        await bloc.refresh();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockFetchUseCase.execute(argThat(searchKeywordEquals(keyword))))
+            .called(1);
+
+        //  エラーが通知されているはず。
+        expect(errorStream, emits(equals(error)));
+
+        //  スワイプ更新時は失敗しても動画リストをクリアしない。
+        //  そのため、リストが更新前の状態であるはず。
+        expect(
+          bloc.list,
+          emits(
+            listPredicate(
+              //  動画4件と末尾のProgressIndicator要素で、合わせて5件のはず。
+              (l) => l.length == 5 && l.last is ProgressIndicatorElement,
+            ),
+          ),
+        );
+
+        //  動画リストが空でないと判定されるはず。
+        expect(bloc.isNotEmpty, emits(equals(true)));
+      });
+    });
+  });
+}
+
+//  最初の検索部分まで処理を進める。
+Future<void> runFirstTimeSearch(
+  SearchPageBloc bloc,
+  MockVideoListFetchUseCase mockFetchUseCase,
+  String keyword,
+) async {
+  when(mockFetchUseCase.execute(any)).thenAnswer(
+    (_) async => VideoListFetchResponseSuccess(
+      List.generate(2, (_) => DummyVideo()),
+      false,
+    ),
+  );
+
+  bloc.keywordSink.add(keyword);
+  await bloc.search();
+
+  //  現在、動画リスト2件で追加取得不可能な状態となっている。
+  expect(
+    bloc.list,
+    emits(
+      listPredicate(
+        (l) => l.length == 2 && l.every((e) => e is VideoElement),
+      ),
+    ),
+  );
+}

--- a/test/search_page_bloc_search_test.dart
+++ b/test/search_page_bloc_search_test.dart
@@ -1,0 +1,123 @@
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+import 'package:youtube_search_app/dummy_video.dart';
+import 'package:youtube_search_app/search/list_element.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
+import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+import 'package:youtube_search_app/video.dart';
+
+import 'matchers.dart';
+import 'mocks.dart';
+
+void main() {
+  group('SearchPageBlocのテスト', () {
+    final mockFetchUseCase = MockVideoListFetchUseCase();
+    final mockAppendUseCase = MockVideoListAppendUseCase();
+
+    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+
+    group('検索のテスト', () {
+      test('成功するケース', () async {
+        final videoList = List.generate(3, (_) => DummyVideo());
+        const hasNextPage = true;
+        final response = VideoListFetchResponseSuccess(videoList, hasNextPage);
+
+        //  ProgressIndicatorの可視性を通知するStreamを記録する。
+        final isProgressIndicatorVisible = ReplaySubject<bool>()
+          ..addStream(bloc.isProgressIndicatorVisible);
+
+        //  検索に成功し、3件の動画が見つかり、追加取得が可能
+        //  という結果を返すように設定する。
+        when(mockFetchUseCase.execute(any)).thenAnswer((_) async => response);
+
+        //  検索キーワードを入力する。
+        const keyword = '検索のテスト成功するケースのキーワード';
+        bloc.keywordSink.add(keyword);
+
+        //  検索処理を走らせる。
+        await bloc.search();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockFetchUseCase.execute(argThat(searchKeywordEquals(keyword))))
+            .called(1);
+
+        //  検索処理の前後でProgressIndicatorが非表示→表示→非表示となったはず。
+        expect(
+            isProgressIndicatorVisible,
+            emitsInOrder(<Matcher>[
+              equals(false),
+              equals(true),
+              equals(false),
+            ]));
+
+        //  動画リストが更新されているはず。
+        expect(
+          bloc.list,
+          emits(
+            listPredicate(
+                //  動画3件に加え、末尾のProgressIndicator要素で要素数が4であるはず。
+                (l) => l.length == 4 && l.last is ProgressIndicatorElement),
+          ),
+        );
+
+        //  動画リストが空ではないことが通知されているはず。
+        expect(bloc.isNotEmpty, emits(equals(true)));
+      });
+
+      test('失敗するケース', () async {
+        const error = FetchErrorType.TokenError;
+        final response = VideoListFetchResponseFailure(error);
+
+        //  errorStreamの発火記録をReplaySubjectで記録しておく。
+        final errorStream = ReplaySubject<FetchErrorType>()
+          ..addStream(bloc.errorStream);
+
+        //  検索に失敗する結果を返すように設定する。
+        when(mockFetchUseCase.execute(any)).thenAnswer((_) async => response);
+
+        //  検索キーワードを入力する。
+        const keyword = '検索のテスト失敗するケースのキーワード';
+        bloc.keywordSink.add(keyword);
+
+        //  検索処理を走らせる。
+        await bloc.search();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockFetchUseCase.execute(argThat(searchKeywordEquals(keyword))))
+            .called(1);
+
+        //  エラーが通知されているはず。
+        expect(errorStream, emits(equals(error)));
+
+        //  動画リストが空であることが通知されているはず。
+        expect(bloc.isNotEmpty, emits(equals(false)));
+      });
+
+      test('取得自体には成功するが、動画リストが空であるケース', () async {
+        final videoList = List<Video>.empty();
+        const hasNextPage = false;
+        final response = VideoListFetchResponseSuccess(videoList, hasNextPage);
+
+        //  検索に成功するが、1件も動画が見つからず、追加取得も不可能
+        //  という結果を返すように設定する。
+        when(mockFetchUseCase.execute(any)).thenAnswer((_) async => response);
+
+        //  検索キーワードを入力する。
+        const keyword = '取得自体には成功するが、動画リストが空であるケースのキーワード';
+        bloc.keywordSink.add(keyword);
+
+        //  検索処理を走らせる。
+        await bloc.search();
+
+        //  ユースケースインタラクタが呼ばれたはず。
+        verify(mockFetchUseCase.execute(argThat(searchKeywordEquals(keyword))))
+            .called(1);
+
+        //  動画リストが空であることが通知されているはず。
+        expect(bloc.isNotEmpty, emits(equals(false)));
+      });
+    });
+  });
+}


### PR DESCRIPTION
#22 の対応

Mockitoを導入して、検索画面のBLoCのテストを実装した。

* 検索処理のテスト
  * 正常に動画リストが取得できるケース
  * 動画リストの取得でトークンエラーになるケース
  * 正常に取得できたものの、動画リストが空になるケース
* スワイプ更新のテスト
  * 正常に更新ができるケース
  * クライアントエラーになるケース
* 追加取得のテスト
  * 正常に更新ができるケース
  * その他のエラーとなるケース
