### PR TITLE
動画再生時にYouTubeにジャンプする処理を実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,21 @@
 PODS:
   - Flutter (1.0.0)
+  - url_launcher (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  url_launcher:
+    :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				C4E89077C62A7A2013AEE61A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -224,6 +225,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C4E89077C62A7A2013AEE61A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		D52ABE95457EA90B56ECB4D9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -9,6 +9,8 @@ import 'package:youtube_search_app/search/usecase/append/video_list_append_inter
 import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_interactor.dart';
 import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/history/save/stub_watch_history_save_interactor.dart';
+import 'package:youtube_search_app/search/usecase/history/save/watch_history_save_use_case.dart';
 
 //  DIコンテナのラッパ
 class Dependency {
@@ -32,9 +34,12 @@ class Dependency {
     GetIt.I.registerFactory<VideoListAppendUseCase>(
       () => VideoListAppendInteractor(resolve()),
     );
+    GetIt.I.registerFactory<WatchHistorySaveUseCase>(
+      () => StubWatchHistorySaveInteractor(),
+    );
 
     GetIt.I.registerFactory<SearchPageBloc>(
-      () => SearchPageBloc(resolve(), resolve()),
+      () => SearchPageBloc(resolve(), resolve(), resolve()),
     );
   }
 

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -7,6 +7,7 @@ import 'package:youtube_search_app/search/search_page_drawer.dart';
 import 'package:youtube_search_app/search/search_keyword_field.dart';
 import 'package:youtube_search_app/search/search_page_list.dart';
 import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
+import 'package:youtube_search_app/youtube_app_launcher.dart';
 
 //  検索ページ
 class SearchPage extends StatelessWidget {
@@ -32,7 +33,11 @@ class _SearchPageContentState extends State<_SearchPageContent> {
     super.didChangeDependencies();
 
     final bloc = Provider.of<SearchPageBloc>(context);
+
     bloc.errorStream.listen(this._onError).addTo(this._compositeSubscription);
+    bloc.videoIdToWatchStream
+        .listen(this._launchYouTubeApp)
+        .addTo(this._compositeSubscription);
   }
 
   @override
@@ -136,5 +141,10 @@ class _SearchPageContentState extends State<_SearchPageContent> {
 
     final snackBar = SnackBar(content: Text(message));
     ScaffoldMessenger.of(this.context).showSnackBar(snackBar);
+  }
+
+  //  YouTubeアプリを開いて動画の視聴を開始する。
+  Future<void> _launchYouTubeApp(String videoId) async {
+    await YouTubeAppLauncher.instance.launchYouTubeApp(videoId);
   }
 }

--- a/lib/search/usecase/history/save/stub_watch_history_save_interactor.dart
+++ b/lib/search/usecase/history/save/stub_watch_history_save_interactor.dart
@@ -1,0 +1,11 @@
+import 'package:youtube_search_app/search/usecase/history/save/watch_history_save_use_case.dart';
+
+class StubWatchHistorySaveInteractor implements WatchHistorySaveUseCase {
+  @override
+  Future<WatchHistorySaveResponse> execute(
+      WatchHistorySaveRequest request) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    return WatchHistorySaveResponse();
+  }
+}

--- a/lib/search/usecase/history/save/watch_history_save_use_case.dart
+++ b/lib/search/usecase/history/save/watch_history_save_use_case.dart
@@ -1,0 +1,17 @@
+import 'package:youtube_search_app/video.dart';
+
+//  視聴履歴を保存する。
+abstract class WatchHistorySaveUseCase {
+  Future<WatchHistorySaveResponse> execute(WatchHistorySaveRequest request);
+}
+
+//  リクエスト
+class WatchHistorySaveRequest {
+  WatchHistorySaveRequest(this.video);
+
+  //  視聴履歴の保存対象の動画
+  final Video video;
+}
+
+//  レスポンス
+class WatchHistorySaveResponse {}

--- a/lib/search/video_view.dart
+++ b/lib/search/video_view.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/search/search_page_bloc.dart';
 import 'package:youtube_search_app/video.dart';
 
 //  検索ページのリストの動画の要素
@@ -16,17 +18,21 @@ class VideoView extends StatelessWidget {
   final Video model;
 
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.fromLTRB(8.0, 0.0, 16.0, 8.0),
-        child: Card(
-          elevation: 3.0,
-          child: InkWell(
-            child: this._buildCardContents(),
-            onTap: () => this._onTap(),
-            onLongPress: () => this._onLongPress(),
-          ),
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<SearchPageBloc>(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8.0, 0.0, 16.0, 8.0),
+      child: Card(
+        elevation: 3.0,
+        child: InkWell(
+          child: this._buildCardContents(),
+          onTap: () => this._onTap(bloc),
+          onLongPress: () => this._onLongPress(),
         ),
-      );
+      ),
+    );
+  }
 
   //  Card内のコンテンツを生成する。
   Widget _buildCardContents() => Column(
@@ -82,7 +88,9 @@ class VideoView extends StatelessWidget {
       );
 
   //  この動画要素がタップされたとき。
-  void _onTap() {}
+  Future<void> _onTap(SearchPageBloc bloc) async {
+    await bloc.onVideoClicked(this.model);
+  }
 
   //  この動画要素が長押しされたとき。
   void _onLongPress() {}

--- a/lib/youtube_app_launcher.dart
+++ b/lib/youtube_app_launcher.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/foundation.dart';
+import 'package:universal_html/html.dart' show window;
+import 'package:url_launcher/url_launcher.dart';
+
+abstract class YouTubeAppLauncher {
+  static YouTubeAppLauncher _instance = null;
+
+  //  シングルトンインスタンス
+  static YouTubeAppLauncher get instance {
+    _instance ??= _YouTubeAppLauncher();
+
+    return _instance;
+  }
+
+  //  指定した動画をYouTube公式アプリで開く。
+  Future<void> launchYouTubeApp(String videoId);
+}
+
+class _YouTubeAppLauncher extends YouTubeAppLauncher {
+  //  iOSのプラットフォーム文字列のリスト
+  static const _iOSPlatforms = ['iPhone', 'iPod', 'iPad'];
+
+  //  iOSのPWAアプリとして動作しているかどうか
+  //  (判定結果をキャッシュしておく。)
+  bool _isPWAiOS = null;
+
+  @override
+  Future<void> launchYouTubeApp(String videoId) async {
+    this._isPWAiOS ??= kIsWeb &&
+        _iOSPlatforms.any((p) => window.navigator.platform.contains(p));
+
+    final uri = this._isPWAiOS
+        ? 'youtube://$videoId'
+        : 'https://www.youtube.com/watch?v=$videoId';
+
+    await launch(uri, forceSafariVC: false, webOnlyWindowName: '_blank');
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,6 +162,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -242,6 +249,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   get_it:
     dependency: "direct main"
     description:
@@ -263,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+4"
   http_multi_server:
     dependency: transitive
     description:
@@ -396,6 +415,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0-nullsafety.3"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   pool:
     dependency: transitive
     description:
@@ -590,6 +616,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.5"
+  universal_html:
+    dependency: "direct main"
+    description:
+      name: universal_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.3"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.7.10"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+9"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.9"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5+1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   vector_math:
     dependency: transitive
     description:
@@ -639,6 +721,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
+  zone_local:
+    dependency: transitive
+    description:
+      name: zone_local
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.16.0 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   json_annotation: ^3.1.1
   retrofit: ^1.3.4+1
   dio: ^3.0.10
+  url_launcher: ^5.7.10
+  universal_html: ^1.2.3
 
 dev_dependencies:
   flutter_test:

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,6 +1,7 @@
 import 'package:mockito/mockito.dart';
 import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/search/usecase/history/save/watch_history_save_use_case.dart';
 
 //  VideoListFetchUseCaseのモック
 class MockVideoListFetchUseCase extends Mock implements VideoListFetchUseCase {}
@@ -8,3 +9,7 @@ class MockVideoListFetchUseCase extends Mock implements VideoListFetchUseCase {}
 //  VideoListAppendUseCaseのモック
 class MockVideoListAppendUseCase extends Mock
     implements VideoListAppendUseCase {}
+
+//  WatchHistorySaveUseCaseのモック
+class MockWatchHistorySaveUseCase extends Mock
+    implements WatchHistorySaveUseCase {}

--- a/test/search_page_bloc_append_test.dart
+++ b/test/search_page_bloc_append_test.dart
@@ -15,8 +15,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
-    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+    final bloc = SearchPageBloc(
+      mockFetchUseCase,
+      mockAppendUseCase,
+      mockHistoryUseCase,
+    );
     const keyword = '検索キーワードてすと';
 
     group('追加取得のテスト', () {

--- a/test/search_page_bloc_refresh_test.dart
+++ b/test/search_page_bloc_refresh_test.dart
@@ -14,8 +14,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
-    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+    final bloc = SearchPageBloc(
+      mockFetchUseCase,
+      mockAppendUseCase,
+      mockHistoryUseCase,
+    );
     const keyword = '検索キーワードてすと';
 
     group('スワイプ更新のテスト', () {

--- a/test/search_page_bloc_search_test.dart
+++ b/test/search_page_bloc_search_test.dart
@@ -15,8 +15,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
-    final bloc = SearchPageBloc(mockFetchUseCase, mockAppendUseCase);
+    final bloc = SearchPageBloc(
+      mockFetchUseCase,
+      mockAppendUseCase,
+      mockHistoryUseCase,
+    );
 
     group('検索のテスト', () {
       test('成功するケース', () async {


### PR DESCRIPTION
#31 の対応

* url_launcherを導入
  * YouTubeへ遷移するため。
* universal_htmlを導入
  * これを使わずにdart:htmlを使用していると、iOSでのビルドにコケるため。
* YouTubeへのジャンプ機能を実装
  * iOSで実行中は `youtube://` スキームを使用して遷移させる。
    * (これをしないとPWAで画面遷移をすると、空っぽの謎のページが作られてしまうため。)
    * 注意: YouTubeのネイティブアプリがインストールされていないと遷移に失敗する。
    * (遷移失敗の判定ができないみたい。)
  * Androidで実行中は普通の `http://youtube.com/watch?v=...` で遷移させる。
    * Androidでは最悪、ネイティブアプリがインストールされていなくても、ブラウザで見れる。
* 動画クリック時に視聴履歴を保存する処理を実装
  * `WatchHistorySaveUseCase` を追加
  * クリック時にBLoCからこれを実行する。