### PR TITLE
フィルタダイアログのUIを実装

### DIFF
--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -1,6 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 import 'package:youtube_search_app/env/env.dart';
+import 'package:youtube_search_app/search/filter/filter_dialog_bloc.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/stub_filtering_options_fetch_interactor.dart';
+import 'package:youtube_search_app/search/filter/usecase/save/filtering_options_save_use_case.dart';
+import 'package:youtube_search_app/search/filter/usecase/save/stub_filtering_options_save_interactor.dart';
 import 'package:youtube_search_app/search/repository/search_repository.dart';
 import 'package:youtube_search_app/search/repository/search_repository_impl.dart';
 import 'package:youtube_search_app/search/repository/youtube_api_service.dart';
@@ -37,9 +42,18 @@ class Dependency {
     GetIt.I.registerFactory<WatchHistorySaveUseCase>(
       () => StubWatchHistorySaveInteractor(),
     );
+    GetIt.I.registerFactory<FilteringOptionsFetchUseCase>(
+      () => StubFilteringOptionsFetchInteractor(),
+    );
+    GetIt.I.registerFactory<FilteringOptionsSaveUseCase>(
+      () => StubFilteringOptionsSaveInteractor(),
+    );
 
     GetIt.I.registerFactory<SearchPageBloc>(
       () => SearchPageBloc(resolve(), resolve(), resolve()),
+    );
+    GetIt.I.registerFactory<FilterDialogBloc>(
+      () => FilterDialogBloc(resolve(), resolve()),
     );
   }
 

--- a/lib/search/filter/filter_dialog.dart
+++ b/lib/search/filter/filter_dialog.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/dependency.dart';
+import 'package:youtube_search_app/search/filter/filter_dialog_bloc.dart';
+import 'package:youtube_search_app/search/filter/regex_field.dart';
+import 'package:youtube_search_app/search/filter/regex_filter_type.dart';
+
+//  フィルタダイアログ
+//  (結果として更新が必要かどうかを表すbool値を返す。)
+class FilterDialog extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Provider<FilterDialogBloc>(
+      create: (context) => Dependency.resolve(),
+      dispose: (context, bloc) => bloc.dispose(),
+      child: _FilterDialog(),
+    );
+  }
+}
+
+class _FilterDialog extends StatelessWidget {
+  static const _regexFilterPopupMenuItems = [
+    PopupMenuItem(value: RegexFilterType.NONE, child: Text('なし')),
+    PopupMenuItem(value: RegexFilterType.WHITE_LIST, child: Text('ホワイトリスト')),
+    PopupMenuItem(value: RegexFilterType.BLACK_LIST, child: Text('ブラックリスト')),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<FilterDialogBloc>(context);
+
+    return this._buildAlertDialog(context, bloc);
+  }
+
+  //  アラートダイアログを生成する。
+  Widget _buildAlertDialog(BuildContext context, FilterDialogBloc bloc) =>
+      AlertDialog(
+        title: const Text('検索フィルタ'),
+        content: this._buildContent(bloc),
+        actions: [
+          this._buildCancelButton(context),
+          this._buildOKButton(context, bloc),
+        ],
+        scrollable: true,
+        titlePadding: const EdgeInsets.all(16),
+        contentPadding: const EdgeInsets.all(16),
+        buttonPadding: const EdgeInsets.all(4),
+        insetPadding: const EdgeInsets.all(8),
+      );
+
+  //  コンテンツを生成する。
+  Widget _buildContent(FilterDialogBloc bloc) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          this._buildWatchedVideoItem(bloc),
+          this._buildBlockedVideoItem(bloc),
+          this._buildBlockedChannelItem(bloc),
+          this._buildRegexItem(bloc),
+          this._buildRegexField(bloc),
+        ],
+      );
+
+  //  視聴済み動画の項目を生成する。
+  Widget _buildWatchedVideoItem(FilterDialogBloc bloc) => StreamBuilder<bool>(
+      stream: bloc.includesWatchedVideos,
+      initialData: true,
+      builder: (context, snapshot) {
+        final includes = snapshot.data;
+
+        return SwitchListTile(
+          title: const Text('視聴済み動画'),
+          subtitle: Text('視聴済みの動画を表示${includes ? 'します。' : 'しません。'}'),
+          value: includes,
+          contentPadding: const EdgeInsets.all(0),
+          onChanged: bloc.onWatchedVideoFilterChanged,
+        );
+      });
+
+  //  ブロック動画の項目を生成する。
+  Widget _buildBlockedVideoItem(FilterDialogBloc bloc) => StreamBuilder<bool>(
+      stream: bloc.includesBlockedVideos,
+      initialData: false,
+      builder: (context, snapshot) {
+        final includes = snapshot.data;
+
+        return SwitchListTile(
+          title: const Text('ブロック動画'),
+          subtitle: Text('ブロックした動画を表示${includes ? 'します。' : 'しません。'}'),
+          value: includes,
+          contentPadding: const EdgeInsets.all(0),
+          onChanged: bloc.onBlockedVideoFilterChanged,
+        );
+      });
+
+  //  ブロックチャンネルの項目を生成する。
+  Widget _buildBlockedChannelItem(FilterDialogBloc bloc) => StreamBuilder<bool>(
+      stream: bloc.includesBlockedChannels,
+      initialData: false,
+      builder: (context, snapshot) {
+        final includes = snapshot.data;
+
+        return SwitchListTile(
+          title: const Text('ブロックチャンネル'),
+          subtitle: Text('ブロックしたチャンネルの動画を表示${includes ? 'します。' : 'しません。'}'),
+          value: includes,
+          contentPadding: const EdgeInsets.all(0),
+          onChanged: bloc.onBlockedChannelFilterChanged,
+        );
+      });
+
+  //  正規表現フィルタの項目を生成する。
+  Widget _buildRegexItem(FilterDialogBloc bloc) => ListTile(
+        title: StreamBuilder<RegexFilterType>(
+          stream: bloc.regexFilterType,
+          initialData: RegexFilterType.NONE,
+          builder: (context, snapshot) => snapshot.data.when(
+            none: () => const Text('正規表現フィルタ (なし)'),
+            white: () => const Text('正規表現フィルタ (ホワイトリスト)'),
+            black: () => const Text('正規表現フィルタ (ブラックリスト)'),
+          ),
+        ),
+        subtitle: StreamBuilder<RegexFilterType>(
+          stream: bloc.regexFilterType,
+          initialData: RegexFilterType.NONE,
+          builder: (context, snapshot) => snapshot.data.when(
+            none: () => const Text('タイトルによるフィルタリングを行いません。'),
+            white: () => const Text('タイトルが正規表現にマッチする動画のみを表示します。'),
+            black: () => const Text('タイトルが正規表現にマッチしない動画のみを表示します。'),
+          ),
+        ),
+        trailing: PopupMenuButton<RegexFilterType>(
+          icon: const Icon(Icons.arrow_drop_down, size: 32),
+          itemBuilder: (context) => _regexFilterPopupMenuItems,
+          onSelected: bloc.onRegexFilterTypeChanged,
+        ),
+        contentPadding: const EdgeInsets.all(0),
+      );
+
+  //  正規表現フィルタの入力フィールドを生成する。
+  Widget _buildRegexField(FilterDialogBloc bloc) =>
+      StreamBuilder<RegexFilterType>(
+        stream: bloc.regexFilterType,
+        initialData: RegexFilterType.NONE,
+        builder: (context, snapshot) =>
+            snapshot.data == RegexFilterType.NONE ? Container() : RegexField(),
+      );
+
+  //  OKボタンを生成する。
+  Widget _buildOKButton(BuildContext context, FilterDialogBloc bloc) =>
+      StreamBuilder<bool>(
+        stream: bloc.isOKButtonEnabled,
+        initialData: false,
+        builder: (context, snapshot) {
+          final isEnabled = snapshot.data;
+          final eventListener =
+              isEnabled ? () => this._onOKButtonClicked(context, bloc) : null;
+
+          return FlatButton(
+            child: const Text('OK'),
+            onPressed: eventListener,
+          );
+        },
+      );
+
+  //  キャンセルボタンを生成する。
+  Widget _buildCancelButton(BuildContext context) => FlatButton(
+        child: const Text('キャンセル'),
+        onPressed: () => Navigator.pop(context, false),
+      );
+
+  //  OKボタンがクリックされたとき。
+  void _onOKButtonClicked(BuildContext context, FilterDialogBloc bloc) {
+    bloc.onOKButtonClicked();
+    Navigator.pop(context, true);
+  }
+}

--- a/lib/search/filter/filter_dialog_bloc.dart
+++ b/lib/search/filter/filter_dialog_bloc.dart
@@ -1,0 +1,162 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:youtube_search_app/search/filter/filtering_options.dart';
+import 'package:youtube_search_app/search/filter/regex_filter_type.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart';
+import 'package:youtube_search_app/search/filter/usecase/save/filtering_options_save_use_case.dart';
+
+//  FilterDialogのBLoC
+class FilterDialogBloc {
+  FilterDialogBloc(this._fetchUseCase, this._saveUseCase) {
+    final response = this._fetchUseCase.execute(FilteringOptionsFetchRequest());
+    final initial = response.options;
+
+    //  フィルタリングオプションの各種項目の初期値を設定する。
+    this._includesWatchedVideos.value = initial.includesWatchedVideos;
+    this._includesBlockedVideos.value = initial.includesBlockedVideos;
+    this._includesBlockedChannels.value = initial.includesBlockedChannels;
+    initial.regexFiltering.when(
+      none: () {
+        this._regexFilterType.value = RegexFilterType.NONE;
+        this._regexFilterPatternStr.value = '';
+      },
+      white: (pattern) {
+        this._regexFilterType.value = RegexFilterType.WHITE_LIST;
+        this._regexFilterPatternStr.value = pattern;
+      },
+      black: (pattern) {
+        this._regexFilterType.value = RegexFilterType.BLACK_LIST;
+        this._regexFilterPatternStr.value = pattern;
+      },
+    );
+
+    //  OKボタンの有効性を通知するストリームを構築する。
+    this._hasAnyChanges = this._createHasAnyChangesStream(initial);
+  }
+
+  final FilteringOptionsFetchUseCase _fetchUseCase;
+  final FilteringOptionsSaveUseCase _saveUseCase;
+
+  //  視聴済み動画を検索結果に含めるかどうか
+  final _includesWatchedVideos = BehaviorSubject<bool>();
+
+  //  ブロックした動画を検索結果に含めるかどうか
+  final _includesBlockedVideos = BehaviorSubject<bool>();
+
+  //  ブロックしたチャンネルの動画を検索結果に含めるかどうか
+  final _includesBlockedChannels = BehaviorSubject<bool>();
+
+  //  正規表現フィルタの種類
+  final _regexFilterType = BehaviorSubject<RegexFilterType>();
+
+  //  正規表現フィルタのパターン文字列
+  final _regexFilterPatternStr = BehaviorSubject<String>();
+
+  //  オプションに変更が存在するかどうか
+  Stream<bool> _hasAnyChanges;
+
+  //  視聴済み動画を検索結果に含めるかどうか
+  Stream<bool> get includesWatchedVideos => this._includesWatchedVideos.stream;
+
+  //  ブロックした動画を検索結果に含めるかどうか
+  Stream<bool> get includesBlockedVideos => this._includesBlockedVideos.stream;
+
+  //  ブロックしたチャンネルの動画を検索結果に含めるかどうか
+  Stream<bool> get includesBlockedChannels =>
+      this._includesBlockedChannels.stream;
+
+  //  正規表現フィルタの種類
+  Stream<RegexFilterType> get regexFilterType => this._regexFilterType.stream;
+
+  //  正規表現フィルタのパターン文字列
+  Stream<String> get regexFilterPatternString =>
+      this._regexFilterPatternStr.stream;
+
+  //  正規表現入力フィールドが有効な状態であるかどうか
+  //  (正規表現フィルタが無効であるか、もしくは、有効である場合に空文字列ではないかどうか)
+  Stream<bool> get isValidRegexFieldState =>
+      Rx.combineLatest2<RegexFilterType, String, bool>(
+        this.regexFilterType,
+        this.regexFilterPatternString,
+        (type, string) => type == RegexFilterType.NONE || string.isNotEmpty,
+      );
+
+  //  OKボタンの活性
+  Stream<bool> get isOKButtonEnabled => Rx.combineLatest2<bool, bool, bool>(
+        this._hasAnyChanges,
+        this.isValidRegexFieldState,
+        (anyChanges, valid) => anyChanges && valid,
+      );
+
+  //  視聴済み動画を検索結果に含めるかどうかの設定が変更されたとき。
+  void onWatchedVideoFilterChanged(bool includes) =>
+      this._includesWatchedVideos.value = includes;
+
+  //  ブロックした動画を検索結果に含めるかどうかの設定が変更されたとき。
+  void onBlockedVideoFilterChanged(bool includes) =>
+      this._includesBlockedVideos.value = includes;
+
+  //  ブロックしたチャンネルの動画を検索結果に含めるかどうかの設定が変更されたとき。
+  void onBlockedChannelFilterChanged(bool includes) =>
+      this._includesBlockedChannels.value = includes;
+
+  //  正規表現フィルタの種類の設定が変更されたとき。
+  void onRegexFilterTypeChanged(RegexFilterType type) =>
+      this._regexFilterType.value = type;
+
+  //  正規表現フィルタのパターン文字列が変更されたとき。
+  void onRegexFilterPatternStringChanged(String pattern) =>
+      this._regexFilterPatternStr.value = pattern;
+
+  //  OKボタンが押されたとき。
+  void onOKButtonClicked() {
+    //  正規表現フィルタのオプションを組み立てる。
+    final regex = this._regexFilterType.value.when(
+          none: () => const RegexFiltering.none(),
+          white: () => RegexFiltering.white(this._regexFilterPatternStr.value),
+          black: () => RegexFiltering.black(this._regexFilterPatternStr.value),
+        );
+
+    //  フィルタリングオプションを組み立てる。
+    final options = FilteringOptions(
+      this._includesWatchedVideos.value,
+      this._includesBlockedVideos.value,
+      this._includesBlockedChannels.value,
+      regex,
+    );
+
+    //  フィルタリングオプションを保存する。
+    this._saveUseCase.execute(FilteringOptionsSaveRequest(options));
+  }
+
+  void dispose() {
+    this._includesWatchedVideos.close();
+    this._includesBlockedVideos.close();
+    this._includesBlockedChannels.close();
+    this._regexFilterType.close();
+    this._regexFilterPatternStr.close();
+  }
+
+  //  変更が存在するかどうか通知するStreamを生成する。
+  Stream<bool> _createHasAnyChangesStream(FilteringOptions initial) =>
+      Rx.combineLatest5<bool, bool, bool, RegexFilterType, String, bool>(
+        this._includesWatchedVideos,
+        this._includesBlockedVideos,
+        this._includesBlockedChannels,
+        this._regexFilterType,
+        this._regexFilterPatternStr,
+        (watched, videos, channels, type, pattern) {
+          //  正規表現フィルタが変更されているどうかを判定する。
+          final isRegexFilteringChanged = initial.regexFiltering.when(
+            none: () => type != RegexFilterType.NONE,
+            white: (p) => type != RegexFilterType.WHITE_LIST || pattern != p,
+            black: (p) => type != RegexFilterType.BLACK_LIST || pattern != p,
+          );
+
+          //  各種オプションが変更されているかどうかを判定する。
+          return isRegexFilteringChanged ||
+              watched != initial.includesWatchedVideos ||
+              videos != initial.includesBlockedVideos ||
+              channels != initial.includesBlockedChannels;
+        },
+      );
+}

--- a/lib/search/filter/filtering_options.dart
+++ b/lib/search/filter/filtering_options.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'filtering_options.freezed.dart';
+
+//  フィルタリングオプション
+@freezed
+abstract class FilteringOptions with _$FilteringOptions {
+  factory FilteringOptions(
+    //  視聴済み動画を含めるかどうか
+    bool includesWatchedVideos,
+
+    //  ブロックした動画を含めるかどうか
+    bool includesBlockedVideos,
+
+    //  ブロックしたチャンネルの動画を含めるかどうか
+    bool includesBlockedChannels,
+
+    //  正規表現フィルタ
+    RegexFiltering regexFiltering,
+  ) = _FilteringOptions;
+}
+
+//  正規表現フィルタ
+@freezed
+abstract class RegexFiltering with _$RegexFiltering {
+  //  フィルタリングなし
+  const factory RegexFiltering.none() = None;
+
+  //  ホワイトリスト方式
+  const factory RegexFiltering.white(String pattern) = White;
+
+  //  ブラックリスト方式
+  const factory RegexFiltering.black(String pattern) = Black;
+}

--- a/lib/search/filter/regex_field.dart
+++ b/lib/search/filter/regex_field.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:youtube_search_app/search/filter/filter_dialog_bloc.dart';
+
+//  正規表現入力フィールド
+class RegexField extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _RegexFieldState();
+}
+
+class _RegexFieldState extends State<RegexField> {
+  TextEditingController _controller = null;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    this._controller = TextEditingController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = Provider.of<FilterDialogBloc>(context);
+
+    TextEditingController().dispose();
+    ScrollController().dispose();
+
+    return StreamBuilder<String>(
+      stream: bloc.regexFilterPatternString,
+      initialData: '',
+      builder: (context, snapshot) {
+        this._controller.value =
+            this._controller.value.copyWith(text: snapshot.data);
+
+        return this._buildTextField(bloc);
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    this._controller.dispose();
+    super.dispose();
+  }
+
+  //  入力フィールドを生成する。
+  Widget _buildTextField(FilterDialogBloc bloc) => StreamBuilder<bool>(
+      stream: bloc.isValidRegexFieldState,
+      initialData: false,
+      builder: (context, snapshot) {
+        final isValid = snapshot.data;
+        final errorText = isValid ? null : '1文字以上入力してください。';
+
+        return TextField(
+          minLines: 1,
+          maxLines: 1,
+          controller: this._controller,
+          decoration: InputDecoration(hintText: '正規表現', errorText: errorText),
+          onChanged: bloc.onRegexFilterPatternStringChanged,
+        );
+      });
+}

--- a/lib/search/filter/regex_filter_type.dart
+++ b/lib/search/filter/regex_filter_type.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+//  正規表現フィルタの種類
+enum RegexFilterType {
+  //  なし
+  NONE,
+
+  //  ホワイトリスト
+  WHITE_LIST,
+
+  //  ブラックリスト
+  BLACK_LIST,
+}
+
+extension RegexFilterTypeEx on RegexFilterType {
+  //  when式の機能を提供する。
+  TResult when<TResult>({
+    @required TResult none(),
+    @required TResult white(),
+    @required TResult black(),
+    TResult onNull(),
+  }) {
+    switch (this) {
+      case RegexFilterType.NONE:
+        return none();
+
+      case RegexFilterType.WHITE_LIST:
+        return white();
+
+      case RegexFilterType.BLACK_LIST:
+        return black();
+
+      default:
+        return onNull();
+    }
+  }
+}

--- a/lib/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart
+++ b/lib/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:youtube_search_app/search/filter/filtering_options.dart';
+
+//  フィルタリングオプションを取得するユースケース
+abstract class FilteringOptionsFetchUseCase {
+  FilteringOptionsFetchResponse execute(FilteringOptionsFetchRequest request);
+}
+
+//  リクエスト
+class FilteringOptionsFetchRequest {}
+
+//  レスポンス
+class FilteringOptionsFetchResponse {
+  FilteringOptionsFetchResponse(this.options);
+
+  final FilteringOptions options;
+}

--- a/lib/search/filter/usecase/fetch/stub_filtering_options_fetch_interactor.dart
+++ b/lib/search/filter/usecase/fetch/stub_filtering_options_fetch_interactor.dart
@@ -1,0 +1,11 @@
+import 'package:youtube_search_app/search/filter/filtering_options.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart';
+
+class StubFilteringOptionsFetchInteractor
+    implements FilteringOptionsFetchUseCase {
+  @override
+  FilteringOptionsFetchResponse execute(FilteringOptionsFetchRequest request) =>
+      FilteringOptionsFetchResponse(
+        FilteringOptions(true, false, false, const RegexFiltering.none()),
+      );
+}

--- a/lib/search/filter/usecase/save/filtering_options_save_use_case.dart
+++ b/lib/search/filter/usecase/save/filtering_options_save_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:youtube_search_app/search/filter/filtering_options.dart';
+
+//  フィルタリングオプションを保存するユースケース
+abstract class FilteringOptionsSaveUseCase {
+  FilteringOptionsSaveResponse execute(FilteringOptionsSaveRequest request);
+}
+
+//  リクエスト
+class FilteringOptionsSaveRequest {
+  FilteringOptionsSaveRequest(this.options);
+
+  final FilteringOptions options;
+}
+
+//  レスポンス
+class FilteringOptionsSaveResponse {}

--- a/lib/search/filter/usecase/save/stub_filtering_options_save_interactor.dart
+++ b/lib/search/filter/usecase/save/stub_filtering_options_save_interactor.dart
@@ -1,0 +1,8 @@
+import 'package:youtube_search_app/search/filter/usecase/save/filtering_options_save_use_case.dart';
+
+class StubFilteringOptionsSaveInteractor
+    implements FilteringOptionsSaveUseCase {
+  @override
+  FilteringOptionsSaveResponse execute(FilteringOptionsSaveRequest request) =>
+      FilteringOptionsSaveResponse();
+}

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:youtube_search_app/dependency.dart';
+import 'package:youtube_search_app/search/filter/filter_dialog.dart';
+import 'package:youtube_search_app/search/search_keyword_field.dart';
 import 'package:youtube_search_app/search/search_page_bloc.dart';
 import 'package:youtube_search_app/search/search_page_drawer.dart';
-import 'package:youtube_search_app/search/search_keyword_field.dart';
 import 'package:youtube_search_app/search/search_page_list.dart';
 import 'package:youtube_search_app/search/usecase/fetch_error_type.dart';
 import 'package:youtube_search_app/youtube_app_launcher.dart';
@@ -114,7 +115,16 @@ class _SearchPageContentState extends State<_SearchPageContent> {
       const Center(child: CircularProgressIndicator());
 
   //  フィルタアイコンが押されたとき。
-  void _onFilterIconPressed() {}
+  Future<void> _onFilterIconPressed() async {
+    final shouldUpdate = await showDialog<bool>(
+      context: context,
+      builder: (context) => FilterDialog(),
+    );
+
+    if (shouldUpdate == true) {
+      //  TODO: 更新
+    }
+  }
 
   //  キーボードを非表示にする。
   void _dismissKeyboard(BuildContext context) {

--- a/test/filter_dialog_bloc_test.dart
+++ b/test/filter_dialog_bloc_test.dart
@@ -1,0 +1,127 @@
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+import 'package:youtube_search_app/search/filter/filter_dialog_bloc.dart';
+import 'package:youtube_search_app/search/filter/filtering_options.dart';
+import 'package:youtube_search_app/search/filter/regex_filter_type.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart';
+import 'package:youtube_search_app/search/filter/usecase/save/filtering_options_save_use_case.dart';
+
+import 'mocks.dart';
+
+void main() {
+  group('FilterDialogBlocのテスト', () {
+    final mockFetchUseCase = MockFilteringOptionsFetchUseCase();
+    final mockSaveUseCase = MockFilteringOptionsSaveUseCase();
+
+    //  設定の初期値 (前回使用していた設定値) を設定する。
+    const initIncludesWatchedVideos = false;
+    const initIncludesBlockedVideos = true;
+    const initIncludesBlockedChannels = false;
+    const initRegexPatternString = '(.*)R18(.*)';
+    const initRegexFiltering = RegexFiltering.black(initRegexPatternString);
+    final initialOptions = FilteringOptions(
+      initIncludesWatchedVideos,
+      initIncludesBlockedVideos,
+      initIncludesBlockedChannels,
+      initRegexFiltering,
+    );
+    when(mockFetchUseCase.execute(any)).thenAnswer(
+      (_) => FilteringOptionsFetchResponse(initialOptions),
+    );
+
+    final bloc = FilterDialogBloc(mockFetchUseCase, mockSaveUseCase);
+
+    test('前回の設定から設定の初期値を復元するテスト', () {
+      //  視聴済み動画の設定項目が初期値と同じはず。
+      expect(
+        bloc.includesWatchedVideos,
+        emits(equals(initIncludesWatchedVideos)),
+      );
+
+      //  ブロック済み動画の設定項目が初期値と同じはず。
+      expect(
+        bloc.includesBlockedVideos,
+        emits(equals(initIncludesBlockedVideos)),
+      );
+
+      //  ブロック済みチャンネルの設定項目が初期値と同じはず。
+      expect(
+        bloc.includesBlockedChannels,
+        emits(equals(initIncludesBlockedChannels)),
+      );
+
+      //  正規表現フィルタの設定項目が初期値と同じはず。
+      expect(
+        bloc.regexFilterType,
+        emits(equals(RegexFilterType.BLACK_LIST)),
+      );
+      expect(
+        bloc.regexFilterPatternString,
+        emits(equals(initRegexPatternString)),
+      );
+    });
+
+    test('OKボタンの活性のテスト', () async {
+      final isOKButtonEnabled = BehaviorSubject<bool>()
+        ..addStream(bloc.isOKButtonEnabled);
+
+      //  初期状態から何も操作していなければOKボタンは無効なはず。
+      await expectLater(
+        await isOKButtonEnabled.firstWhere((isEnabled) => !isEnabled),
+        equals(false),
+      );
+
+      //  初期状態から何かしら操作を行うとOKボタンが有効となるはず。
+      //  (視聴済み動画の設定項目を変更してみる。)
+      bloc.onWatchedVideoFilterChanged(!initIncludesWatchedVideos);
+      await expectLater(
+        await isOKButtonEnabled.firstWhere((isEnabled) => isEnabled),
+        equals(true),
+      );
+
+      //  初期状態と同じ状態に戻す操作を行うとOKボタンが再び無効となるはず。
+      //  (視聴済み動画の設定項目を元に戻してみる。)
+      bloc.onWatchedVideoFilterChanged(initIncludesWatchedVideos);
+      await expectLater(
+        await isOKButtonEnabled.firstWhere((isEnabled) => !isEnabled),
+        equals(false),
+      );
+
+      //  正規表現文字列を変更するとOKボタンが有効になるはず。
+      bloc.onRegexFilterPatternStringChanged('変更された正規表現文字列');
+      await expectLater(
+        await isOKButtonEnabled.firstWhere((isEnabled) => isEnabled),
+        equals(true),
+      );
+    }, timeout: const Timeout(Duration(seconds: 1)));
+
+    test('OKボタンを押すと設定値を保存するテスト', () {
+      //  まだ保存処理は呼ばれていないはず。
+      verifyNever(mockSaveUseCase.execute(any));
+
+      //  オプションを色々と変更してみる。
+      bloc.onWatchedVideoFilterChanged(true);
+      bloc.onBlockedVideoFilterChanged(false);
+      bloc.onBlockedChannelFilterChanged(true);
+      bloc.onRegexFilterTypeChanged(RegexFilterType.BLACK_LIST);
+      bloc.onRegexFilterPatternStringChanged('(.*)R15(.*)');
+
+      final expectedOptions = FilteringOptions(
+        true,
+        false,
+        true,
+        const RegexFiltering.black('(.*)R15(.*)'),
+      );
+
+      //  OKボタンを押すと設定したオプションの保存処理が呼ばれるはず。
+      bloc.onOKButtonClicked();
+      verify(
+        mockSaveUseCase.execute(argThat(predicate<FilteringOptionsSaveRequest>(
+          (request) => request.options == expectedOptions,
+        ))),
+      ).called(equals(1));
+      verifyNoMoreInteractions(mockSaveUseCase);
+    });
+  });
+}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,4 +1,6 @@
 import 'package:mockito/mockito.dart';
+import 'package:youtube_search_app/search/filter/usecase/fetch/filtering_options_fetch_use_case.dart';
+import 'package:youtube_search_app/search/filter/usecase/save/filtering_options_save_use_case.dart';
 import 'package:youtube_search_app/search/usecase/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/search/usecase/fetch/video_list_fetch_use_case.dart';
 import 'package:youtube_search_app/search/usecase/history/save/watch_history_save_use_case.dart';
@@ -13,3 +15,11 @@ class MockVideoListAppendUseCase extends Mock
 //  WatchHistorySaveUseCaseのモック
 class MockWatchHistorySaveUseCase extends Mock
     implements WatchHistorySaveUseCase {}
+
+//  FilteringOptionsFetchUseCaseのモック
+class MockFilteringOptionsFetchUseCase extends Mock
+    implements FilteringOptionsFetchUseCase {}
+
+//  FilteringOptionsSaveUseCaseのモック
+class MockFilteringOptionsSaveUseCase extends Mock
+    implements FilteringOptionsSaveUseCase {}


### PR DESCRIPTION
* フィルタダイアログ (`FilterDialog`) のUIを実装
  * 以下のオプションを持つ。
    * 視聴済み動画を含めるかどうかのオプション
    * ブロックした動画を含めるかどうかのオプション
    * ブロックしたチャンネルの動画を含めるかどうかのオプション
    * 正規表現フィルタのオプション
  * 前回のオプションを復元するユースケース (`FilteringOptionsFetchUseCase`) のスタブを追加
  * オプションを保存するユースケース (`FilteringOptionsSaveUseCase`) のスタブを追加
* テストコードを追加