### PR TITLE
動画リストのリロード処理を実装

### DIFF
--- a/lib/application/search/append/video_list_append_interactor.dart
+++ b/lib/application/search/append/video_list_append_interactor.dart
@@ -1,5 +1,7 @@
 import 'package:youtube_search_app/application/search/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/application/search/search_repository.dart';
+import 'package:youtube_search_app/application/search/search_result.dart';
+import 'package:youtube_search_app/application/search/video_converter.dart';
 
 class VideoListAppendInteractor implements VideoListAppendUseCase {
   VideoListAppendInteractor(this._searchRepository);
@@ -13,9 +15,16 @@ class VideoListAppendInteractor implements VideoListAppendUseCase {
 
     return result.when(
       //  取得に成功した場合、フィルタリングして返す。
-      success: (list, hasNext) {
+      success: (result) {
+        //  TODO: 視聴履歴の検索処理
+        //  TODO: ブロックデータの取得処理
         //  TODO: フィルタリング処理
-        return VideoListAppendResponse.success(list, hasNext);
+
+        final videoList = result.videos
+            .map((item) => VideoConverter.convert(item, null, false, false))
+            .toList(growable: false);
+
+        return VideoListAppendResponse.success(videoList, result.hasNextPage);
       },
 
       //  取得に失敗した場合、エラーを返す。

--- a/lib/application/search/fetch/video_list_fetch_interactor.dart
+++ b/lib/application/search/fetch/video_list_fetch_interactor.dart
@@ -1,5 +1,7 @@
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
 import 'package:youtube_search_app/application/search/search_repository.dart';
+import 'package:youtube_search_app/application/search/search_result.dart';
+import 'package:youtube_search_app/application/search/video_converter.dart';
 
 class VideoListFetchInteractor implements VideoListFetchUseCase {
   VideoListFetchInteractor(this._searchRepository);
@@ -12,9 +14,16 @@ class VideoListFetchInteractor implements VideoListFetchUseCase {
 
     return result.when(
       //  取得に成功した場合、オプションに応じてフィルタリングする。
-      success: (list, hasNext) {
+      success: (result) {
+        //  TODO: 視聴履歴の検索処理
+        //  TODO: ブロックデータの取得処理
         //  TODO: フィルタリング処理
-        return VideoListFetchResponse.success(list, hasNext);
+
+        final videoList = result.videos
+            .map((item) => VideoConverter.convert(item, null, false, false))
+            .toList(growable: false);
+
+        return VideoListFetchResponse.success(videoList, result.hasNextPage);
       },
 
       //  取得に失敗した場合、エラーとして返す。

--- a/lib/application/search/reload/video_list_reload_interactor.dart
+++ b/lib/application/search/reload/video_list_reload_interactor.dart
@@ -1,11 +1,27 @@
 import 'package:youtube_search_app/application/search/reload/video_list_reload_use_case.dart';
+import 'package:youtube_search_app/application/search/search_repository.dart';
+import 'package:youtube_search_app/application/search/search_result.dart';
+import 'package:youtube_search_app/application/search/video_converter.dart';
 
 class VideoListReloadInteractor implements VideoListReloadUseCase {
+  VideoListReloadInteractor(this._repository);
+
+  final SearchRepository _repository;
+
   @override
   Future<VideoListReloadResponse> execute(
       VideoListReloadRequest request) async {
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    final result = this._repository.getSearchResult();
+    //  TODO: 視聴履歴の検索処理
+    //  TODO: ブロックデータの取得処理
+    //  TODO: フィルタリング処理
 
-    return VideoListReloadResponse(List.empty(), false);
+    final videoList = result.videos
+        .map((item) => VideoConverter.convert(item, null, false, false))
+        .toList(growable: false);
+
+    //  TODO: 検索履歴の更新
+
+    return VideoListReloadResponse(videoList, result.hasNextPage);
   }
 }

--- a/lib/application/search/reload/video_list_reload_interactor.dart
+++ b/lib/application/search/reload/video_list_reload_interactor.dart
@@ -1,0 +1,11 @@
+import 'package:youtube_search_app/application/search/reload/video_list_reload_use_case.dart';
+
+class VideoListReloadInteractor implements VideoListReloadUseCase {
+  @override
+  Future<VideoListReloadResponse> execute(
+      VideoListReloadRequest request) async {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    return VideoListReloadResponse(List.empty(), false);
+  }
+}

--- a/lib/application/search/reload/video_list_reload_use_case.dart
+++ b/lib/application/search/reload/video_list_reload_use_case.dart
@@ -1,0 +1,22 @@
+//  動画リストをリロードするユースケース
+import 'package:youtube_search_app/model/video.dart';
+
+abstract class VideoListReloadUseCase {
+  //  動画リストをリロードする。
+  //  (フィルタオプションが更新されたときに呼ばれる。)
+  Future<VideoListReloadResponse> execute(VideoListReloadRequest request);
+}
+
+//  リクエスト
+class VideoListReloadRequest {}
+
+//  レスポンス
+class VideoListReloadResponse {
+  VideoListReloadResponse(this.videoList, this.hasNextPage);
+
+  //  結果の動画リスト
+  final List<Video> videoList;
+
+  //  次のページが存在するかどうか
+  final bool hasNextPage;
+}

--- a/lib/application/search/search_repository.dart
+++ b/lib/application/search/search_repository.dart
@@ -1,11 +1,15 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
-import 'package:youtube_search_app/model/video.dart';
+import 'package:youtube_search_app/application/search/search_result.dart';
 
 part 'search_repository.freezed.dart';
 
 //  検索処理のリポジトリ
 abstract class SearchRepository {
+  //  直近の検索結果を取得する。
+  //  (存在しない場合はnullを返す。)
+  SearchResult getSearchResult();
+
   //  検索を行う。
   Future<SearchRepositoryResult> search(String keyword);
 
@@ -17,14 +21,7 @@ abstract class SearchRepository {
 @freezed
 abstract class SearchRepositoryResult with _$SearchRepositoryResult {
   //  成功
-  const factory SearchRepositoryResult.success(
-    //  検索結果の動画リスト
-    //  (追加取得分も前回取得分も含めた、フィルタ未適用のリスト)
-    List<Video> searchResultVideoList,
-
-    //  検索結果に次のページが存在するかどうか。
-    bool hasNextPage,
-  ) = Success;
+  const factory SearchRepositoryResult.success(SearchResult result) = Success;
 
   //  失敗
   const factory SearchRepositoryResult.failure(FetchErrorType cause) = Failure;

--- a/lib/application/search/search_result.dart
+++ b/lib/application/search/search_result.dart
@@ -1,0 +1,19 @@
+import 'package:youtube_search_app/model/video_item.dart';
+
+//  検索結果
+abstract class SearchResult {
+  //  検索クエリ
+  String get query;
+
+  //  検索結果の動画リストのリスト
+  List<List<VideoItem>> get videoLists;
+
+  //  次の検索ページが存在するかどうか
+  bool get hasNextPage;
+}
+
+extension SearchResultEx on SearchResult {
+  //  全ページの結果をまとめた動画リストを取得する。
+  List<VideoItem> get videos =>
+      this.videoLists.expand((innerList) => innerList).toList();
+}

--- a/lib/application/search/video_converter.dart
+++ b/lib/application/search/video_converter.dart
@@ -1,0 +1,25 @@
+import 'package:youtube_search_app/model/video.dart';
+import 'package:youtube_search_app/model/video_item.dart';
+
+//  Videoのコンバータ
+abstract class VideoConverter {
+  //  VideoItem型をVideo型に変換する。
+  static Video convert(
+    VideoItem item,
+    DateTime watchedAt,
+    bool isBlockedVideo,
+    bool isBlockedChannel,
+  ) =>
+      Video(
+        item.videoId,
+        item.title,
+        item.description,
+        item.thumbnailUrl,
+        item.uploadedAt,
+        item.channelId,
+        item.channelTitle,
+        watchedAt,
+        isBlockedVideo,
+        isBlockedChannel,
+      );
+}

--- a/lib/data/search/fetch_error_type_converter.dart
+++ b/lib/data/search/fetch_error_type_converter.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:youtube_search_app/application/fetch_error_type.dart';
+
+//  FetchErrorTypeのコンバータ
+abstract class FetchErrorTypeConverter {
+  //  例外をFetchErrorTypeに変換する。
+  static FetchErrorType convert(Exception e) {
+    if (e is DioError) {
+      print('DIOエラー: $e');
+
+      switch (e.type) {
+        //  トークンまわりのエラー
+        case DioErrorType.RESPONSE:
+          return FetchErrorType.TokenError;
+
+        //  タイムアウト系はGoogleのサーバが遅いことはあまり考えられないため、
+        //  クライアント側のエラーとみなしてしまう。
+        case DioErrorType.CONNECT_TIMEOUT:
+        case DioErrorType.SEND_TIMEOUT:
+        case DioErrorType.RECEIVE_TIMEOUT:
+          return FetchErrorType.ClientError;
+
+        //  オフライン環境で実行するとSocketExceptionが投げられる。
+        case DioErrorType.DEFAULT:
+          return e.response is SocketException
+              ? FetchErrorType.ClientError
+              : FetchErrorType.UnknownError;
+
+        default:
+          return FetchErrorType.UnknownError;
+      }
+    } else {
+      print('エラー: $e');
+      return FetchErrorType.UnknownError;
+    }
+  }
+}

--- a/lib/data/search/video_item_converter.dart
+++ b/lib/data/search/video_item_converter.dart
@@ -1,0 +1,26 @@
+import 'package:youtube_search_app/data/api/search_result.dart';
+import 'package:youtube_search_app/model/video_item.dart';
+
+//  VideoItemのコンバータ
+abstract class VideoItemConverter {
+  //  YouTubeの検索APIのレスポンスのItem型をVideoItem型に変換する。
+  static VideoItem convert(Item item) {
+    final videoId = item.id.videoId;
+    final title = item.snippet.title;
+    final description = item.snippet.description;
+    final thumbnailUrl = item.snippet.thumbnails.medium.url;
+    final uploadedAt = item.snippet.publishedAt;
+    final channelId = item.snippet.channelId;
+    final channelTitle = item.snippet.channelTitle;
+
+    return VideoItem(
+      videoId,
+      title,
+      description,
+      thumbnailUrl,
+      uploadedAt,
+      channelId,
+      channelTitle,
+    );
+  }
+}

--- a/lib/data/search/youtube_search_result.dart
+++ b/lib/data/search/youtube_search_result.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:youtube_search_app/application/search/search_result.dart';
+import 'package:youtube_search_app/model/video_item.dart';
+
+part 'youtube_search_result.freezed.dart';
+
+//  YouTubeの検索結果
+//  (アプリケーション層のSearchResultの派生)
+@freezed
+abstract class YouTubeSearchResult implements _$YouTubeSearchResult {
+  factory YouTubeSearchResult(
+    String query,
+    List<List<VideoItem>> videoLists,
+    @nullable String nextPageToken,
+  ) =>
+      YouTubeSearchResult.create(
+        query,
+        videoLists,
+        nextPageToken,
+        nextPageToken != null,
+      );
+
+  @Implements(SearchResult)
+  const factory YouTubeSearchResult.create(
+    String query,
+    List<List<VideoItem>> videoLists,
+    @nullable String nextPageToken,
+    bool hasNextPage,
+  ) = _YouTubeSearchResult;
+
+  const YouTubeSearchResult._();
+
+  SearchResult asSearchResult() => this as SearchResult;
+}

--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -42,7 +42,7 @@ class Dependency {
       () => VideoListAppendInteractor(resolve()),
     );
     GetIt.I.registerFactory<VideoListReloadUseCase>(
-      () => VideoListReloadInteractor(),
+      () => VideoListReloadInteractor(resolve()),
     );
     GetIt.I.registerFactory<WatchHistorySaveUseCase>(
       () => StubWatchHistorySaveInteractor(),

--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -10,6 +10,8 @@ import 'package:youtube_search_app/application/search/filter/fetch/filtering_opt
 import 'package:youtube_search_app/application/search/filter/fetch/stub_filtering_options_fetch_interactor.dart';
 import 'package:youtube_search_app/application/search/filter/save/filtering_options_save_use_case.dart';
 import 'package:youtube_search_app/application/search/filter/save/stub_filtering_options_save_interactor.dart';
+import 'package:youtube_search_app/application/search/reload/video_list_reload_interactor.dart';
+import 'package:youtube_search_app/application/search/reload/video_list_reload_use_case.dart';
 import 'package:youtube_search_app/application/search/search_repository.dart';
 import 'package:youtube_search_app/data/api/youtube_api_service.dart';
 import 'package:youtube_search_app/data/search/search_repository_impl.dart';
@@ -39,6 +41,9 @@ class Dependency {
     GetIt.I.registerFactory<VideoListAppendUseCase>(
       () => VideoListAppendInteractor(resolve()),
     );
+    GetIt.I.registerFactory<VideoListReloadUseCase>(
+      () => VideoListReloadInteractor(),
+    );
     GetIt.I.registerFactory<WatchHistorySaveUseCase>(
       () => StubWatchHistorySaveInteractor(),
     );
@@ -50,7 +55,7 @@ class Dependency {
     );
 
     GetIt.I.registerFactory<SearchPageBloc>(
-      () => SearchPageBloc(resolve(), resolve(), resolve()),
+      () => SearchPageBloc(resolve(), resolve(), resolve(), resolve()),
     );
     GetIt.I.registerFactory<FilterDialogBloc>(
       () => FilterDialogBloc(resolve(), resolve()),

--- a/lib/model/video_item.dart
+++ b/lib/model/video_item.dart
@@ -1,11 +1,11 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-part 'video.freezed.dart';
+part 'video_item.freezed.dart';
 
-//  動画の情報と視聴履歴とブロック情報を持つモデル
+//  動画の情報を持つモデル
 @freezed
-abstract class Video with _$Video {
-  factory Video(
+abstract class VideoItem with _$VideoItem {
+  factory VideoItem(
     //  動画ID
     String videoId,
 
@@ -26,14 +26,5 @@ abstract class Video with _$Video {
 
     //  この動画を投稿したチャンネル名
     String channelTitle,
-
-    //  視聴日時
-    @nullable DateTime watchedAt,
-
-    //  ブロックされている動画かどうか
-    bool isBlockedVideo,
-
-    //  ブロックされているチャンネルの動画かどうか
-    bool isBlockedChannel,
-  ) = _Video;
+  ) = _VideoItem;
 }

--- a/lib/ui/search/search_page.dart
+++ b/lib/ui/search/search_page.dart
@@ -46,7 +46,7 @@ class _SearchPageContentState extends State<_SearchPageContent> {
     final bloc = Provider.of<SearchPageBloc>(context);
 
     return Scaffold(
-      appBar: this._buildAppBar(),
+      appBar: this._buildAppBar(bloc),
       drawer: SearchPageDrawer(),
       body: this._buildBody(context, bloc),
     );
@@ -59,15 +59,15 @@ class _SearchPageContentState extends State<_SearchPageContent> {
   }
 
   //  アプリバーを生成する。
-  PreferredSizeWidget _buildAppBar() => AppBar(
+  PreferredSizeWidget _buildAppBar(SearchPageBloc bloc) => AppBar(
         title: SearchKeywordField(),
-        actions: [this._buildFilterIcon()],
+        actions: [this._buildFilterIcon(bloc)],
       );
 
   //  フィルタアイコンを生成する。
-  Widget _buildFilterIcon() => IconButton(
+  Widget _buildFilterIcon(SearchPageBloc bloc) => IconButton(
         icon: const Icon(Icons.filter_list),
-        onPressed: () => this._onFilterIconPressed(),
+        onPressed: () => this._onFilterIconPressed(bloc),
       );
 
   //  ボディを生成する。
@@ -115,15 +115,13 @@ class _SearchPageContentState extends State<_SearchPageContent> {
       const Center(child: CircularProgressIndicator());
 
   //  フィルタアイコンが押されたとき。
-  Future<void> _onFilterIconPressed() async {
-    final shouldUpdate = await showDialog<bool>(
+  Future<void> _onFilterIconPressed(SearchPageBloc bloc) async {
+    final updated = await showDialog<bool>(
       context: context,
       builder: (context) => FilterDialog(),
     );
 
-    if (shouldUpdate == true) {
-      //  TODO: 更新
-    }
+    if (updated == true) await bloc.onFilterOptionsUpdated();
   }
 
   //  キーボードを非表示にする。

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -4,6 +4,7 @@ import 'package:youtube_search_app/application/search/append/video_list_append_u
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
 import 'package:youtube_search_app/application/search/filter/fetch/filtering_options_fetch_use_case.dart';
 import 'package:youtube_search_app/application/search/filter/save/filtering_options_save_use_case.dart';
+import 'package:youtube_search_app/application/search/reload/video_list_reload_use_case.dart';
 
 //  VideoListFetchUseCaseのモック
 class MockVideoListFetchUseCase extends Mock implements VideoListFetchUseCase {}
@@ -11,6 +12,10 @@ class MockVideoListFetchUseCase extends Mock implements VideoListFetchUseCase {}
 //  VideoListAppendUseCaseのモック
 class MockVideoListAppendUseCase extends Mock
     implements VideoListAppendUseCase {}
+
+//  VideoListReloadUseCaseのモック
+class MockVideoListReloadUseCase extends Mock
+    implements VideoListReloadUseCase {}
 
 //  WatchHistorySaveUseCaseのモック
 class MockWatchHistorySaveUseCase extends Mock

--- a/test/search_page_bloc_append_test.dart
+++ b/test/search_page_bloc_append_test.dart
@@ -15,11 +15,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
     final bloc = SearchPageBloc(
       mockFetchUseCase,
       mockAppendUseCase,
+      mockReloadUseCase,
       mockHistoryUseCase,
     );
     const keyword = '検索キーワードてすと';

--- a/test/search_page_bloc_refresh_test.dart
+++ b/test/search_page_bloc_refresh_test.dart
@@ -14,11 +14,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
     final bloc = SearchPageBloc(
       mockFetchUseCase,
       mockAppendUseCase,
+      mockReloadUseCase,
       mockHistoryUseCase,
     );
     const keyword = '検索キーワードてすと';

--- a/test/search_page_bloc_search_test.dart
+++ b/test/search_page_bloc_search_test.dart
@@ -15,11 +15,13 @@ void main() {
   group('SearchPageBlocのテスト', () {
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
+    final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
     final bloc = SearchPageBloc(
       mockFetchUseCase,
       mockAppendUseCase,
+      mockReloadUseCase,
       mockHistoryUseCase,
     );
 


### PR DESCRIPTION
#37 の対応

* `VideoItem` 型を導入
* `SearchResult` 型を導入
* リポジトリのシグネチャを変更
* フィルタ更新時にリロードを行うユースケースをコールするように修正