### PR TITLE
フィルタリング機能を実装

### DIFF
--- a/lib/application/search/append/video_list_append_interactor.dart
+++ b/lib/application/search/append/video_list_append_interactor.dart
@@ -4,6 +4,7 @@ import 'package:youtube_search_app/application/search/append/video_list_append_u
 import 'package:youtube_search_app/application/search/search_repository.dart';
 import 'package:youtube_search_app/application/search/search_result.dart';
 import 'package:youtube_search_app/application/search/video_converter.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 import 'package:youtube_search_app/model/video_item.dart';
 
@@ -26,10 +27,8 @@ class VideoListAppendInteractor implements VideoListAppendUseCase {
     final response = result.when(
       //  取得に成功した場合、フィルタリングして返す。
       success: (result) async {
-        //  TODO: フィルタリング処理
-        final videoList = await Future.wait(
-          result.videos.map((item) async => this.toVideo(item)),
-        );
+        final videoList =
+            await this._convert(result.videos, request.options).toList();
 
         return VideoListAppendResponse.success(videoList, result.hasNextPage);
       },
@@ -41,19 +40,27 @@ class VideoListAppendInteractor implements VideoListAppendUseCase {
     return await response;
   }
 
-  Future<Video> toVideo(VideoItem item) async {
-    final watchedAt =
-        await this._watchHistoryRepository.getWatchedAt(item.videoId);
-    final videoBlockedAt =
-        await this._blockListRepository.getVideoBlockedAt(item.videoId);
-    final channelBlockedAt =
-        await this._blockListRepository.getChannelBlockedAt(item.channelId);
+//  動画リストの変換を掛ける。
+  Stream<Video> _convert(List<VideoItem> list, FilteringOptions filter) async* {
+    for (final item in list) {
+      //  履歴データを取得する。
+      final watchedAt =
+          await this._watchHistoryRepository.getWatchedAt(item.videoId);
+      final videoBlockedAt =
+          await this._blockListRepository.getVideoBlockedAt(item.videoId);
+      final channelBlockedAt =
+          await this._blockListRepository.getChannelBlockedAt(item.channelId);
 
-    return VideoConverter.convert(
-      item,
-      watchedAt,
-      videoBlockedAt != null,
-      channelBlockedAt != null,
-    );
+      //  Video型に変換する。
+      final video = VideoConverter.convert(
+        item,
+        watchedAt,
+        videoBlockedAt != null,
+        channelBlockedAt != null,
+      );
+
+      //  フィルタリングを掛けて、対象のみ含めるようにする。
+      if (filter.shouldInclude(video)) yield video;
+    }
   }
 }

--- a/lib/application/search/append/video_list_append_use_case.dart
+++ b/lib/application/search/append/video_list_append_use_case.dart
@@ -1,16 +1,22 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 
 part 'video_list_append_use_case.freezed.dart';
 
-//  動画リストの追加取得を行う。
+//  動画リストの追加取得を行うユースケース
 abstract class VideoListAppendUseCase {
   Future<VideoListAppendResponse> execute(VideoListAppendRequest request);
 }
 
 //  リクエスト
-class VideoListAppendRequest {}
+class VideoListAppendRequest {
+  VideoListAppendRequest(this.options);
+
+  //  フィルタリングオプション
+  FilteringOptions options;
+}
 
 //  レスポンス
 @freezed

--- a/lib/application/search/fetch/video_list_fetch_use_case.dart
+++ b/lib/application/search/fetch/video_list_fetch_use_case.dart
@@ -1,10 +1,11 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 
 part 'video_list_fetch_use_case.freezed.dart';
 
-//  動画リストを取得する。
+//  動画リストを取得するユースケース
 abstract class VideoListFetchUseCase {
   Future<VideoListFetchResponse> execute(VideoListFetchRequest request);
 }
@@ -16,9 +17,8 @@ class VideoListFetchRequest {
   //  キーワード
   final String keyword;
 
-  //  検索オプション
-  //  (仮)
-  final Object options;
+  //  フィルタオプション
+  final FilteringOptions options;
 }
 
 //  レスポンス

--- a/lib/application/search/reload/video_list_reload_interactor.dart
+++ b/lib/application/search/reload/video_list_reload_interactor.dart
@@ -4,6 +4,7 @@ import 'package:youtube_search_app/application/search/reload/video_list_reload_u
 import 'package:youtube_search_app/application/search/search_repository.dart';
 import 'package:youtube_search_app/application/search/search_result.dart';
 import 'package:youtube_search_app/application/search/video_converter.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 import 'package:youtube_search_app/model/video_item.dart';
 
@@ -22,30 +23,33 @@ class VideoListReloadInteractor implements VideoListReloadUseCase {
   Future<VideoListReloadResponse> execute(
       VideoListReloadRequest request) async {
     final result = this._searchRepository.getSearchResult();
-
-    //  TODO: フィルタリング処理
-    final videoList = await Future.wait(
-      result.videos.map((item) async => this.toVideo(item)),
-    );
-
-    //  TODO: 検索履歴の更新
+    final videoList =
+        await this._convert(result.videos, request.options).toList();
 
     return VideoListReloadResponse(videoList, result.hasNextPage);
   }
 
-  Future<Video> toVideo(VideoItem item) async {
-    final watchedAt =
-        await this._watchHistoryRepository.getWatchedAt(item.videoId);
-    final videoBlockedAt =
-        await this._blockListRepository.getVideoBlockedAt(item.videoId);
-    final channelBlockedAt =
-        await this._blockListRepository.getChannelBlockedAt(item.channelId);
+  //  動画リストの変換を掛ける。
+  Stream<Video> _convert(List<VideoItem> list, FilteringOptions filter) async* {
+    for (final item in list) {
+      //  履歴データを取得する。
+      final watchedAt =
+          await this._watchHistoryRepository.getWatchedAt(item.videoId);
+      final videoBlockedAt =
+          await this._blockListRepository.getVideoBlockedAt(item.videoId);
+      final channelBlockedAt =
+          await this._blockListRepository.getChannelBlockedAt(item.channelId);
 
-    return VideoConverter.convert(
-      item,
-      watchedAt,
-      videoBlockedAt != null,
-      channelBlockedAt != null,
-    );
+      //  Video型に変換する。
+      final video = VideoConverter.convert(
+        item,
+        watchedAt,
+        videoBlockedAt != null,
+        channelBlockedAt != null,
+      );
+
+      //  フィルタリングを掛けて、対象のみ含めるようにする。
+      if (filter.shouldInclude(video)) yield video;
+    }
   }
 }

--- a/lib/application/search/reload/video_list_reload_use_case.dart
+++ b/lib/application/search/reload/video_list_reload_use_case.dart
@@ -1,14 +1,21 @@
 //  動画リストをリロードするユースケース
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 
+//  動画リストをリロードするユースケース
 abstract class VideoListReloadUseCase {
-  //  動画リストをリロードする。
+  //  現時点で取得済みの動画リストをリロードする。
   //  (フィルタオプションが更新されたときに呼ばれる。)
   Future<VideoListReloadResponse> execute(VideoListReloadRequest request);
 }
 
 //  リクエスト
-class VideoListReloadRequest {}
+class VideoListReloadRequest {
+  VideoListReloadRequest(this.options);
+
+  //  フィルタリングオプション
+  final FilteringOptions options;
+}
 
 //  レスポンス
 class VideoListReloadResponse {

--- a/lib/dependency.dart
+++ b/lib/dependency.dart
@@ -70,7 +70,13 @@ class Dependency {
     );
 
     GetIt.I.registerFactory<SearchPageBloc>(
-      () => SearchPageBloc(resolve(), resolve(), resolve(), resolve()),
+      () => SearchPageBloc(
+        resolve(),
+        resolve(),
+        resolve(),
+        resolve(),
+        resolve(),
+      ),
     );
     GetIt.I.registerFactory<FilterDialogBloc>(
       () => FilterDialogBloc(resolve(), resolve()),

--- a/lib/model/filtering_options.dart
+++ b/lib/model/filtering_options.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:youtube_search_app/model/video.dart';
 
 part 'filtering_options.freezed.dart';
 
@@ -31,4 +32,30 @@ abstract class RegexFiltering with _$RegexFiltering {
 
   //  ブラックリスト方式
   const factory RegexFiltering.black(String pattern) = Black;
+}
+
+extension FilteringOptionsExtension on FilteringOptions {
+  //  対象の動画をフィルタリングによって含めるべきかどうかを判定する。
+  bool shouldInclude(Video video) {
+    //  視聴済み動画のフィルタリングをする。
+    if (!this.includesWatchedVideos && video.hasBeenWatched) return false;
+
+    //  ブロック済み動画のフィルタリングをする。
+    if (!this.includesBlockedVideos && video.isBlockedVideo) return false;
+
+    //  ブロック済みチャンネルのフィルタリングをする。
+    if (!this.includesBlockedChannels && video.isBlockedChannel) return false;
+
+    //  最後に正規表現フィルタリングをする。
+    return this.regexFiltering.when(
+          //  正規表現フィルタリングなしの場合、問答無用で含めるべきと判定する。
+          none: () => true,
+
+          //  ホワイトリスト方式の場合、マッチしたら含めるべきと判定する。
+          white: (pattern) => RegExp(pattern).hasMatch(video.title),
+
+          //  ブラックリスト方式の場合、マッチしたら含めるべきでないと判定する。
+          black: (pattern) => !RegExp(pattern).hasMatch(video.title),
+        );
+  }
 }

--- a/lib/model/video.dart
+++ b/lib/model/video.dart
@@ -37,3 +37,8 @@ abstract class Video with _$Video {
     bool isBlockedChannel,
   ) = _Video;
 }
+
+extension VideoExtension on Video {
+  //  視聴済みかどうか
+  bool get hasBeenWatched => this.watchedAt != null;
+}

--- a/lib/ui/search/list/video_view.dart
+++ b/lib/ui/search/list/video_view.dart
@@ -92,7 +92,7 @@ class VideoView extends StatelessWidget {
 
   //  動画の視聴日時を生成する。
   Widget _buildWatchedAt() {
-    if (this.model.watchedAt == null) return Container();
+    if (!this.model.hasBeenWatched) return Container();
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/ui/search/search_page_bloc.dart
+++ b/lib/ui/search/search_page_bloc.dart
@@ -3,19 +3,23 @@ import 'package:youtube_search_app/application/fetch_error_type.dart';
 import 'package:youtube_search_app/application/history/watch/save/watch_history_save_use_case.dart';
 import 'package:youtube_search_app/application/search/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/application/search/filter/fetch/filtering_options_fetch_use_case.dart';
 import 'package:youtube_search_app/application/search/reload/video_list_reload_use_case.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 import 'package:youtube_search_app/ui/search/list/list_element.dart';
 
 //  検索ページのBLoC
 class SearchPageBloc {
   SearchPageBloc(
+    this._filteringOptionsFetchUseCase,
     this._videoListFetchUseCase,
     this._videoListAppendUseCase,
     this._videoListReloadUseCase,
     this._watchHistorySaveUseCase,
   );
 
+  final FilteringOptionsFetchUseCase _filteringOptionsFetchUseCase;
   final VideoListFetchUseCase _videoListFetchUseCase;
   final VideoListAppendUseCase _videoListAppendUseCase;
   final VideoListReloadUseCase _videoListReloadUseCase;
@@ -53,6 +57,12 @@ class SearchPageBloc {
 
   //  動画を開くイベントを通知するSubject
   final _videoOpenEventSubject = PublishSubject<String>();
+
+  //  検索フィルタリングオプションを取得する。
+  FilteringOptions get _options => this
+      ._filteringOptionsFetchUseCase
+      .execute(FilteringOptionsFetchRequest())
+      .options;
 
   //  ビジー状態 (通信状態) かどうか
   //  (4通りの更新処理のうち、いずれかが行われているかどうか)
@@ -107,7 +117,7 @@ class SearchPageBloc {
 
     this._isFetching.add(true);
 
-    final request = VideoListFetchRequest(this._keyword.value, null);
+    final request = VideoListFetchRequest(this._keyword.value, this._options);
     final response = await this._videoListFetchUseCase.execute(request);
 
     response.when(
@@ -128,7 +138,7 @@ class SearchPageBloc {
 
     this._isSwipeRefreshing.add(true);
 
-    final request = VideoListFetchRequest(this._keyword.value, null);
+    final request = VideoListFetchRequest(this._keyword.value, this._options);
     final response = await this._videoListFetchUseCase.execute(request);
 
     response.when(
@@ -149,7 +159,7 @@ class SearchPageBloc {
 
     this._isFetchingAdditionally.add(true);
 
-    final request = VideoListAppendRequest(null);
+    final request = VideoListAppendRequest(this._options);
     final response = await this._videoListAppendUseCase.execute(request);
 
     response.when(
@@ -187,7 +197,7 @@ class SearchPageBloc {
     this._isApplyingSearchFilters.add(true);
 
     //  動画リストをリロードする。
-    final request = VideoListReloadRequest(null);
+    final request = VideoListReloadRequest(this._options);
     final response = await this._videoListReloadUseCase.execute(request);
     this._onFetchSuccess(response.videoList, response.hasNextPage);
 

--- a/lib/ui/search/search_page_bloc.dart
+++ b/lib/ui/search/search_page_bloc.dart
@@ -149,7 +149,7 @@ class SearchPageBloc {
 
     this._isFetchingAdditionally.add(true);
 
-    final request = VideoListAppendRequest();
+    final request = VideoListAppendRequest(null);
     final response = await this._videoListAppendUseCase.execute(request);
 
     response.when(
@@ -187,7 +187,7 @@ class SearchPageBloc {
     this._isApplyingSearchFilters.add(true);
 
     //  動画リストをリロードする。
-    final request = VideoListReloadRequest();
+    final request = VideoListReloadRequest(null);
     final response = await this._videoListReloadUseCase.execute(request);
     this._onFetchSuccess(response.videoList, response.hasNextPage);
 

--- a/test/filtering_options_test.dart
+++ b/test/filtering_options_test.dart
@@ -1,0 +1,162 @@
+import 'package:test/test.dart';
+import 'package:youtube_search_app/model/dummy_video.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
+
+void main() {
+  group('フィルタリングオプションのテスト', () {
+    final video = DummyVideo.create();
+    final videos = [
+      video.copyWith(
+        title: '動画1',
+        watchedAt: null,
+        isBlockedVideo: false,
+        isBlockedChannel: false,
+      ),
+      video.copyWith(
+        title: '動画2',
+        watchedAt: DateTime.now(),
+        isBlockedVideo: false,
+        isBlockedChannel: false,
+      ),
+      video.copyWith(
+        title: '動画3',
+        watchedAt: DateTime.now(),
+        isBlockedVideo: true,
+        isBlockedChannel: false,
+      ),
+      video.copyWith(
+        title: '動画4',
+        watchedAt: null,
+        isBlockedVideo: false,
+        isBlockedChannel: true,
+      ),
+      video.copyWith(
+        title: '動画5',
+        watchedAt: DateTime.now(),
+        isBlockedVideo: true,
+        isBlockedChannel: true,
+      ),
+    ];
+
+    test('すべてを含めるケースのテスト', () {
+      final options =
+          FilteringOptions(true, true, true, const RegexFiltering.none());
+
+      final expected = [true, true, true, true, true];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('視聴済み動画のテスト', () {
+      //  視聴済み動画を含めない設定
+      final options =
+          FilteringOptions(false, true, true, const RegexFiltering.none());
+
+      final expected = [true, false, false, true, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('ブロック済み動画のテスト', () {
+      //  ブロック済み動画を含めない設定
+      final options =
+          FilteringOptions(true, false, true, const RegexFiltering.none());
+
+      final expected = [true, true, false, true, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('ブロック済みチャンネルのテスト', () {
+      //  ブロック済みチャンネルを含めない設定
+      final options =
+          FilteringOptions(true, true, false, const RegexFiltering.none());
+
+      final expected = [true, true, true, false, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('ホワイトリスト方式正規表現フィルタのテスト', () {
+      //  タイトルに「2」か「3」が含まれる動画のみを含める設定
+      final options = FilteringOptions(
+        true,
+        true,
+        true,
+        const RegexFiltering.white('(.*)[2-3](.*)'),
+      );
+
+      final expected = [false, true, true, false, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('ブラックリスト方式正規表現フィルタのテスト', () {
+      //  タイトルに「1」か「2」か「3」が含まれない動画のみを含める設定
+      final options = FilteringOptions(
+        true,
+        true,
+        true,
+        const RegexFiltering.black('(.*)[1-3](.*)'),
+      );
+
+      final expected = [false, false, false, true, true];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('視聴済み動画とブロック済み動画の組み合わせのテスト', () {
+      //  視聴済み動画とブロック済み動画を含めない設定
+      final options =
+          FilteringOptions(false, false, true, const RegexFiltering.none());
+
+      final expected = [true, false, false, true, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('視聴済み動画とブロック済みチャンネルの組み合わせのテスト', () {
+      //  視聴済み動画とブロック済みチャンネルを含めない設定
+      final options =
+          FilteringOptions(false, true, false, const RegexFiltering.none());
+
+      final expected = [true, false, false, false, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('ブロック済み動画とブロック済みチャンネルの組み合わせのテスト', () {
+      //  ブロック済み動画とブロック済みチャンネルを含めない設定
+      final options =
+          FilteringOptions(true, false, false, const RegexFiltering.none());
+
+      final expected = [true, true, false, false, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+
+    test('視聴済み動画と正規表現フィルタのテスト', () {
+      //  視聴済み動画とタイトルに「1」から「3」を含めない設定
+      final options = FilteringOptions(
+        false,
+        true,
+        true,
+        const RegexFiltering.black('(.*)[1-3](.*)'),
+      );
+
+      final expected = [false, false, false, true, false];
+      final actual = videos.map(options.shouldInclude);
+
+      expect(actual, orderedEquals(expected));
+    });
+  });
+}

--- a/test/search_page_bloc_append_test.dart
+++ b/test/search_page_bloc_append_test.dart
@@ -4,7 +4,9 @@ import 'package:test/test.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
 import 'package:youtube_search_app/application/search/append/video_list_append_use_case.dart';
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/application/search/filter/fetch/filtering_options_fetch_use_case.dart';
 import 'package:youtube_search_app/model/dummy_video.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/ui/search/list/list_element.dart';
 import 'package:youtube_search_app/ui/search/search_page_bloc.dart';
 
@@ -13,12 +15,19 @@ import 'mocks.dart';
 
 void main() {
   group('SearchPageBlocのテスト', () {
+    final mockOptionsUseCase = MockFilteringOptionsFetchUseCase();
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
     final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
+    when(mockOptionsUseCase.execute(any)).thenReturn(
+      FilteringOptionsFetchResponse(
+          FilteringOptions(true, false, false, const RegexFiltering.none())),
+    );
+
     final bloc = SearchPageBloc(
+      mockOptionsUseCase,
       mockFetchUseCase,
       mockAppendUseCase,
       mockReloadUseCase,

--- a/test/search_page_bloc_refresh_test.dart
+++ b/test/search_page_bloc_refresh_test.dart
@@ -3,7 +3,9 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/application/search/filter/fetch/filtering_options_fetch_use_case.dart';
 import 'package:youtube_search_app/model/dummy_video.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/ui/search/list/list_element.dart';
 import 'package:youtube_search_app/ui/search/search_page_bloc.dart';
 
@@ -12,12 +14,19 @@ import 'mocks.dart';
 
 void main() {
   group('SearchPageBlocのテスト', () {
+    final mockOptionsUseCase = MockFilteringOptionsFetchUseCase();
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
     final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
+    when(mockOptionsUseCase.execute(any)).thenReturn(
+      FilteringOptionsFetchResponse(
+          FilteringOptions(true, false, false, const RegexFiltering.none())),
+    );
+
     final bloc = SearchPageBloc(
+      mockOptionsUseCase,
       mockFetchUseCase,
       mockAppendUseCase,
       mockReloadUseCase,

--- a/test/search_page_bloc_search_test.dart
+++ b/test/search_page_bloc_search_test.dart
@@ -3,7 +3,9 @@ import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 import 'package:youtube_search_app/application/fetch_error_type.dart';
 import 'package:youtube_search_app/application/search/fetch/video_list_fetch_use_case.dart';
+import 'package:youtube_search_app/application/search/filter/fetch/filtering_options_fetch_use_case.dart';
 import 'package:youtube_search_app/model/dummy_video.dart';
+import 'package:youtube_search_app/model/filtering_options.dart';
 import 'package:youtube_search_app/model/video.dart';
 import 'package:youtube_search_app/ui/search/list/list_element.dart';
 import 'package:youtube_search_app/ui/search/search_page_bloc.dart';
@@ -13,12 +15,19 @@ import 'mocks.dart';
 
 void main() {
   group('SearchPageBlocのテスト', () {
+    final mockOptionsUseCase = MockFilteringOptionsFetchUseCase();
     final mockFetchUseCase = MockVideoListFetchUseCase();
     final mockAppendUseCase = MockVideoListAppendUseCase();
     final mockReloadUseCase = MockVideoListReloadUseCase();
     final mockHistoryUseCase = MockWatchHistorySaveUseCase();
 
+    when(mockOptionsUseCase.execute(any)).thenReturn(
+      FilteringOptionsFetchResponse(
+          FilteringOptions(true, false, false, const RegexFiltering.none())),
+    );
+
     final bloc = SearchPageBloc(
+      mockOptionsUseCase,
       mockFetchUseCase,
       mockAppendUseCase,
       mockReloadUseCase,


### PR DESCRIPTION
#46 の対応

* `FilteringOptions#shouldInclude()` を追加
  * 指定動画を含めるかどうかの判定ロジック
* 検索系ユースケースインタラクタにフィルタリング処理を追加
* テストコードを追加 (`filtering_options_test.dart`)

(フィルタリングオプションの永続化をしていないため、見かけ上の進捗はゼロ! w)