### PR TITLE
検索結果が空のときにリロードを行うとNoSuchMethodErrorが出るバグを修正

### DIFF
--- a/lib/application/search/reload/video_list_reload_interactor.dart
+++ b/lib/application/search/reload/video_list_reload_interactor.dart
@@ -23,6 +23,8 @@ class VideoListReloadInteractor implements VideoListReloadUseCase {
   Future<VideoListReloadResponse> execute(
       VideoListReloadRequest request) async {
     final result = this._searchRepository.getSearchResult();
+    if (result == null) return VideoListReloadResponse(List.empty(), false);
+
     final videoList =
         await this._convert(result.videos, request.options).toList();
 


### PR DESCRIPTION
普通にnullの場合を考慮してなかった。

```
Performing hot restart...
Syncing files to device iPhone SE (2nd generation)...
Restarted application in 579ms.
[VERBOSE-2:ui_dart_state.cc(177)] Unhandled Exception: NoSuchMethodError: The getter 'videoLists' was called on null.
Receiver: null
Tried calling: videoLists
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:54:5)
#1      SearchResultEx.videos (package:youtube_search_app/application/search/search_result.dart:18:12)
#2      VideoListReloadInteractor.execute (package:youtube_search_app/application/search/reload/video_list_reload_interactor.dart:29:36)
#3      SearchPageBloc.onFilterOptionsUpdated (package:youtube_search_app/ui/search/search_page_bloc.dart:207:57)
#4      _SearchPageContentState._onFilterIconPressed (package:youtube_search_app/ui/search/search_page.dart:124:37)
<asynchronous suspension>
```